### PR TITLE
Capacity support for secondary inventory

### DIFF
--- a/client/services/NUIService.lua
+++ b/client/services/NUIService.lua
@@ -10,9 +10,9 @@ end
 
 -- OpenContainerInventory
 
-NUIService.OpenClanInventory = function (clanName, clanId)
+NUIService.OpenClanInventory = function (clanName, clanId, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type= "clan", title= "" .. clanName .. "", clanid= clanId})
+	SendNUIMessage({action= "display", type= "clan", title= "" .. clanName .. "", clanid= clanId, capacity= capacity})
 	InInventory = true
 end
 
@@ -24,9 +24,9 @@ NUIService.NUITakeFromClan = function (obj)
 	TriggerServerEvent("syn_clan:TakeFromClan", json.encode(obj))
 end
 
-NUIService.OpenContainerInventory = function (ContainerName, Containerid)
+NUIService.OpenContainerInventory = function (ContainerName, Containerid, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type= "Container", title= "" .. ContainerName .. "", Containerid= Containerid})
+	SendNUIMessage({action= "display", type= "Container", title= "" .. ContainerName .. "", Containerid= Containerid, capacity= capacity})
 	InInventory = true
 end
 
@@ -44,9 +44,9 @@ NUIService.CloseInventory = function ()
 	InInventory = false
 end
 
-NUIService.OpenHorseInventory = function (horseTitle, horseId)
+NUIService.OpenHorseInventory = function (horseTitle, horseId, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type= "horse", title= horseTitle, horseid= horseId})
+	SendNUIMessage({action= "display", type= "horse", title= horseTitle, horseid= horseId, capacity= capacity})
 	InInventory = true
 	TriggerEvent("vorp_stables:setClosedInv", true)
 end
@@ -59,9 +59,9 @@ NUIService.NUITakeFromHorse = function (obj)
 	TriggerServerEvent("vorp_stables:TakeFromHorse", json.encode(obj))
 end
 
-NUIService.OpenstealInventory = function (stealName, stealId)
+NUIService.OpenstealInventory = function (stealName, stealId, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type=  "steal", title= stealName, stealId= stealId})
+	SendNUIMessage({action= "display", type=  "steal", title= stealName, stealId= stealId, capacity= capacity})
 	InInventory = true
 	TriggerEvent("vorp_stables:setClosedInv", true)
 end
@@ -74,9 +74,9 @@ NUIService.NUITakeFromsteal = function (obj)
 	TriggerServerEvent("syn_search:TakeFromsteal", json.encode(obj))
 end
 
-NUIService.OpenCartInventory = function (cartName, wagonId)
+NUIService.OpenCartInventory = function (cartName, wagonId, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type= "cart", title= cartName, wagonid= wagonId})
+	SendNUIMessage({action= "display", type= "cart", title= cartName, wagonid= wagonId, capacity= capacity})
 	InInventory = true
 
 	TriggerEvent("vorp_stables:setClosedInv", true)
@@ -91,9 +91,9 @@ NUIService.NUITakeFromCart = function (obj)
 end
 
 
-NUIService.OpenHouseInventory = function (houseName, houseId)
+NUIService.OpenHouseInventory = function (houseName, houseId, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type= "house", title= houseName, houseId= houseId})
+	SendNUIMessage({action= "display", type= "house", title= houseName, houseId= houseId, capacity= capacity})
 	InInventory = true
 end
 
@@ -105,9 +105,9 @@ NUIService.NUITakeFromHouse = function (obj)
 	TriggerServerEvent("vorp_housing:TakeFromHouse", json.encode(obj))
 end
 
-NUIService.OpenHideoutInventory = function (hideoutName, hideoutId)
+NUIService.OpenHideoutInventory = function (hideoutName, hideoutId, capacity)
 	SetNuiFocus(true, true)
-	SendNUIMessage({action= "display", type= "hideout", title= hideoutName , hideoutId= hideoutId})
+	SendNUIMessage({action= "display", type= "hideout", title= hideoutName , hideoutId= hideoutId, capacity= capacity})
 	InInventory = true
 end
 

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -31,7 +31,7 @@ files {
 
 server_exports { 'vorp_inventoryApi' }
 
-version '1.0.4'
+version '1.0.5'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3'
 vorp_github 'https://github.com/VORPCORE/vorp_inventory-lua'

--- a/html/css/ui.min.css
+++ b/html/css/ui.min.css
@@ -144,6 +144,15 @@ body {
     overflow-x: hidden;
     z-index: 1;
 }
+
+
+.capacity {
+    /* Tested at 2k res */
+    margin-left: 775px;
+    margin-top: 47vh;
+    font-size: 17px;
+}
+
 /* description*/
 #information { 
     text-align: center;

--- a/html/ui.html
+++ b/html/ui.html
@@ -32,14 +32,16 @@
         </div>
 
 
-
+        
     </div>
     <div id="secondInventoryHud">
         <div id="titleHorse"></div>
         <div id="secondInventoryElement">
         </div>
         <p id="information2"></p>
-
+        <div class="capacity">
+            <a id="current-cap-value"></a>/<a id="capacity-value"></a>
+        </div>
     </div>
 
     <script type="text/javascript" src="js/vendor/jquery-3.3.1.min.js"></script>
@@ -67,7 +69,7 @@
         var Containerid = 0
         var horseid = 0
         var wagonid = 0
-
+        var secondaryCapacityAvailable = false
 
         function OverSetTitle(title) {
             document.getElementById("information").innerHTML = title;
@@ -77,8 +79,35 @@
             document.getElementById("information2").innerHTML = title;
         }
 
-        function HorseSetTitle(title) {
+        function secondarySetTitle(title) {
             document.getElementById("titleHorse").innerHTML = title;
+        }
+
+        function secondarySetCurrentCapacity(cap) {
+            document.getElementById('current-cap-value').innerHTML = cap
+        }
+
+        function secondarySetCapacity(cap) {
+            secondaryCapacityAvailable = true
+            document.getElementById('capacity-value').innerHTML = cap
+            secondarySetCurrentCapacity('0')
+        }
+
+        function hideSecondaryCapacity() {
+            secondaryCapacityAvailable = false
+            $(".capacity").remove();
+        }
+
+        function initiateSecondaryInventory(id, title, capacity) {
+            $("#secondInventoryHud").fadeIn();
+            secondarySetTitle(title);
+
+            if (capacity) {
+                secondarySetCapacity(capacity);
+            } else {
+                // Backwards compatible, inventory capacity will not show
+                hideSecondaryCapacity();
+            }
         }
 
         window.addEventListener('message', function (event) {
@@ -782,52 +811,34 @@
 
 
                     if (event.data.type == "horse") {
-                        $("#secondInventoryHud").fadeIn();
-
                         horseid = event.data.horseid;
-                        HorseSetTitle(event.data.title);
+                        initiateSecondaryInventory(horseid, event.data.title, event.data.capacity)
                     }
 
                     if (event.data.type == "cart") {
-                        $("#secondInventoryHud").fadeIn();
                         wagonid = event.data.wagonid;
-                        HorseSetTitle(event.data.title);
+                        initiateSecondaryInventory(wagonid, event.data.title, event.data.capacity)
                     }
 
                     if (event.data.type == "house") {
-                        $("#secondInventoryHud").fadeIn();
-
-                        HorseSetTitle(event.data.title);
-
                         houseId = event.data.houseId;
+                        initiateSecondaryInventory(houseId, event.data.title, event.data.capacity)
                     }
                     if (event.data.type == "hideout") {
-                        $("#secondInventoryHud").fadeIn();
-
-                        HorseSetTitle(event.data.title);
-
                         hideoutId = event.data.hideoutId;
+                        initiateSecondaryInventory(hideoutId, event.data.title, event.data.capacity)
                     }
                     if (event.data.type == "clan") {
-                        $("#secondInventoryHud").fadeIn();
-
-                        HorseSetTitle(event.data.title);
-
                         clanid = event.data.clanid;
+                        initiateSecondaryInventory(clanid, event.data.title, event.data.capacity)
                     }
                     if (event.data.type == "steal") {
-                        $("#secondInventoryHud").fadeIn();
-
-                        HorseSetTitle(event.data.title);
-
                         stealid = event.data.stealId;
+                        initiateSecondaryInventory(stealid, event.data.title, event.data.capacity)
                     }
                     if (event.data.type == "Container") {
-                        $("#secondInventoryHud").fadeIn();
-
-                        HorseSetTitle(event.data.title);
-
-                        Containerid = event.data.Containerid;
+                       Containerid = event.data.Containerid;
+                       initiateSecondaryInventory(Containerid, event.data.title, event.data.capacity)
                     }
 
                     disabled = false;
@@ -891,7 +902,17 @@
 
                 } else if (event.data.action == "setSecondInventoryItems") {
                     secondInventorySetup(event.data.itemList);
-
+                    if (secondaryCapacityAvailable == true) {
+                        // Get how many items are in inventory
+                        let l = event.data.itemList.length
+                        let itemlist = event.data.itemList
+                        let total = 0
+                        let p = 0
+                        for (p; p < l; p++) {
+                            total += Number(itemlist[p].count)
+                        }
+                        secondarySetCurrentCapacity(total)
+                    }
                 } else if (event.data.action == "nearPlayers") {
                     if (event.data.what == "give") {
                         selectPlayerToGive(event.data);

--- a/version
+++ b/version
@@ -1,3 +1,5 @@
+<1.0.5>
+- secondary inventory capacity support
 <1.0.4>
 - fix exploit for decimal values being and when moving giving droping items that would make items be unlimited and not even removable
 - update fxmanifest << yes update


### PR DESCRIPTION
**What this PR adds:**
1. Client support for inventory capacity for secondary inventories (Backwards compatible, capacity will not display if not used)
![image](https://user-images.githubusercontent.com/10902965/172787114-58f83753-9eef-479c-bb00-b598d21fa64e.png)

[Trello Task](https://trello.com/c/88eIeusw/8-add-inventory-capacity-to-horse-housing-inventory-ui-and-api)

**Caution**
_This has only been tested on a 2k monitor (other resolutions need to be tested/added)_