### PR TITLE
1.0.5 Version Bump

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -31,7 +31,7 @@ files {
 
 server_exports { 'vorp_inventoryApi' }
 
-version '1.0.4'
+version '1.0.5'
 vorp_checker 'yes'
 vorp_name '^4Resource version Check^3'
 vorp_github 'https://github.com/VORPCORE/vorp_inventory-lua'

--- a/version
+++ b/version
@@ -1,3 +1,7 @@
+<1.0.5>
+- Open Inventory from InventoryAPI Added
+- Show server ID when giving items/money/weapons
+- canCarryItem InventoryAPI Bugfix
 <1.0.4>
 - fix exploit for decimal values being and when moving giving droping items that would make items be unlimited and not even removable
 - update fxmanifest << yes update


### PR DESCRIPTION
I just realized we did not bump the version with the last set of updates. Bumping to 1.0.5