### PR TITLE
Fix(?) for shared custom inventories

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -1123,36 +1123,36 @@ InventoryAPI.openCustomInventory = function(player, id)
 				InventoryAPI.reloadInventory(_source, id)
 			end)
 		end
-	end
-
-	if UsersInventories[id][identifier] then
-		TriggerClientEvent("vorp_inventory:OpenCustomInv", _source, CustomInventoryInfos[id].name, id, capacity)
-		InventoryAPI.reloadInventory(_source, id)
 	else
-		DbService.GetInventory(charIdentifier, id, function(inventory)
-			local characterInventory = {}
-			for _, item in pairs(inventory) do
-				if svItems[item.item] ~= nil then
-					local dbItem = svItems[item.item]
-					characterInventory[item.id] = Item:New({
-						count = tonumber(item.amount),
-						id = item.id,
-						limit = dbItem.limit,
-						label = dbItem.label,
-						metadata = SharedUtils.MergeTables(dbItem.metadata, item.metadata),
-						name = dbItem.item,
-						type = dbItem.type,
-						canUse = dbItem.usable,
-						canRemove = dbItem.can_remove,
-						createdAt = item.created_at,
-						owner = charIdentifier
-					})
-				end
-			end
-			UsersInventories[id][identifier] = characterInventory
+		if UsersInventories[id][identifier] then
 			TriggerClientEvent("vorp_inventory:OpenCustomInv", _source, CustomInventoryInfos[id].name, id, capacity)
 			InventoryAPI.reloadInventory(_source, id)
-		end)
+		else
+			DbService.GetInventory(charIdentifier, id, function(inventory)
+				local characterInventory = {}
+				for _, item in pairs(inventory) do
+					if svItems[item.item] ~= nil then
+						local dbItem = svItems[item.item]
+						characterInventory[item.id] = Item:New({
+							count = tonumber(item.amount),
+							id = item.id,
+							limit = dbItem.limit,
+							label = dbItem.label,
+							metadata = SharedUtils.MergeTables(dbItem.metadata, item.metadata),
+							name = dbItem.item,
+							type = dbItem.type,
+							canUse = dbItem.usable,
+							canRemove = dbItem.can_remove,
+							createdAt = item.created_at,
+							owner = charIdentifier
+						})
+					end
+				end
+				UsersInventories[id][identifier] = characterInventory
+				TriggerClientEvent("vorp_inventory:OpenCustomInv", _source, CustomInventoryInfos[id].name, id, capacity)
+				InventoryAPI.reloadInventory(_source, id)
+			end)
+		end
 	end
 end
 


### PR DESCRIPTION
Not sure if it's a proper fix. I've done superficial reverse engineering and that's what I came up with. It works, but I'm not sure about its reliability.

The problem before the fix:
https://streamable.com/pmk6df

What was causing the problem:
Basically, the inventory was sent two times in two different formats. The fact that the problem looked so "random" was caused by something like a race condition, the last query to finish was the inventory that would get loaded.

After the patch:
The script now works for both shared and private custom inventories, you can transfer items without problems. Looks like it's fixed, but again - I'm not sure if this fix could lead to other bugs which I hadn't considered.