### PR TITLE
Added ignoreStackLimit parameter and Fix for weapon transfer

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -7,7 +7,8 @@ CustomInventoryInfos = {
 		limit = Config.MaxItemsInInventory.Items,
 		shared = false,
 		---@type table<string, integer>
-		limitedItems = {}
+		limitedItems = {},
+		ignoreItemStackLimit = false
 	}
 }
 
@@ -981,8 +982,9 @@ InventoryAPI.onNewCharacter = function(playerId)
 	end
 end
 
-InventoryAPI.registerInventory = function(id, name, limit, acceptWeapons, shared)
+InventoryAPI.registerInventory = function(id, name, limit, acceptWeapons, shared, ignoreItemStackLimit)
 	limit = limit and limit or -1
+	ignoreItemStackLimit = ignoreItemStackLimit and ignoreItemStackLimit or false
 	acceptWeapons = acceptWeapons and acceptWeapons or true
 	shared = shared and shared or false
 	if CustomInventoryInfos[id] then
@@ -994,6 +996,7 @@ InventoryAPI.registerInventory = function(id, name, limit, acceptWeapons, shared
 		limit = limit,
 		acceptWeapons = acceptWeapons,
 		shared = shared,
+		ignoreItemStackLimit = ignoreItemStackLimit,
 		limitedItems = {}
 	}
 	UsersInventories[id] = {}

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -975,9 +975,10 @@ InventoryService.TakeFromCustom = function(obj)
 	if item.type == "item_weapon" then
 		InventoryAPI.canCarryAmountWeapons(_source, 1, function(res)
 			if res then
-				exports.ghmattimysql:execute("UPDATE loadout SET curr_inv = 'default' WHERE charidentifier = @charid AND id = @weaponId;", {
+				exports.ghmattimysql:execute("UPDATE loadout SET curr_inv = 'default', charidentifier = @charid, identifier = @identifier WHERE id = @weaponId;", {
 					['charid'] = sourceCharIdentifier,
 					['weaponId'] = item.id,
+					['identifier'] = sourceIdentifier
 				})
 				UsersWeapons[invId][item.id]:setCurrInv("default")
 				UsersWeapons["default"][item.id] = UsersWeapons[invId][item.id]

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -334,7 +334,7 @@ InventoryService.addItem = function(target, invId, name, amount, metadata, cb)
 		local item = SvUtils.FindItemByNameAndMetadata(invId, identifier, name, metadata)
 		if item ~= nil then
 			if amount > 0 then
-				item:addCount(amount)
+				item:addCount(amount, CustomInventoryInfos[invId].ignoreItemStackLimit)
 				DbService.SetItemAmount(item:getOwner(), item:getId(), item:getCount())
 				cb(item)
 				return

--- a/shared/models/ItemClass.lua
+++ b/shared/models/ItemClass.lua
@@ -86,8 +86,8 @@ function Item:getCount()
 	return self.count
 end
 
-function Item:addCount(amount)
-	if self.count + amount <= self.limit then
+function Item:addCount(amount, ignoreStackLimit)
+	if (self.count + amount <= self.limit) or ignoreStackLimit then
 		self.count = self.count + amount
 		return true
 	end

--- a/vorpInventoryApi.lua
+++ b/vorpInventoryApi.lua
@@ -1,8 +1,8 @@
 exports('vorp_inventoryApi',function()
     local self = {}
 
-    self.registerInventory = function(id, name, limit, acceptWeapons, shared)
-        TriggerEvent("vorpCore:registerInventory", id, name, limit, acceptWeapons, shared)
+    self.registerInventory = function(id, name, limit, acceptWeapons, shared, ignoreItemStackLimit)
+        TriggerEvent("vorpCore:registerInventory", id, name, limit, acceptWeapons, shared, ignoreItemStackLimit)
     end
 
     self.removeInventory = function(id)


### PR DESCRIPTION
Added a parameter for the registerInventory API method which allows ignoring the item stack limit on the target custom inventory.

Example of actual behavior:
Users can carry a max of 30 rocks, deposit can't have more than 30 rocks even though the deposit limit is, let's say, 1000.

Example of wanted behavior:
User can carry a max of 30 rocks, deposit can have more than 30 rocks until it reaches the inventory maximum along with other items.

The `ignoreItemStackLimit` parameter is set to false by default.
