### PR TITLE
Update inventoryApiService.lua

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -595,9 +595,9 @@ InventoryAPI.subItem = function(player, name, amount, metadata)
 
 	if userInventory then
 		local item = SvUtils.FindItemByNameAndMetadata("default", identifier, name, metadata)
-		-- if item == nil then
-		-- 	item = SvUtils.FindItemByNameAndMetadata("default", identifier, name, nil)
-		-- end
+		if item == nil then 
+			item = SvUtils.FindItemByName("default", identifier, name)
+		end
 		if item then
 			local sourceItemCount = item:getCount()
 


### PR DESCRIPTION
when using item with metadata there is a bug where it doesnt use the item unless u specify in the subitem api the items meta data. if you dont it doesnt take anything. this adds the ability to remove any item with a matching name if the metadata isnt identified. achieving backwards compatibility with older script models that didnt account for meta data when using the subitem api 