### PR TITLE
[FIX] Item duplication when taking items from a custom inventory

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -277,7 +277,7 @@ InventoryService.usedWeapon = function(id, _used, _used2)
 	end)
 end
 
-InventoryService.subItem = function(target, invId, itemId, amount, cb)
+InventoryService.subItem = function(target, invId, itemId, amount)
 	local _source = target
 	local sourceCharacter = Core.getUser(_source).getUsedCharacter
 	local identifier = sourceCharacter.identifier
@@ -303,14 +303,8 @@ InventoryService.subItem = function(target, invId, itemId, amount, cb)
 				else
 					DbService.SetItemAmount(item:getOwner(), itemId, item:getCount())
 				end
-				if cb then 
-					cb(true) 
-				end
 			end
 		end
-	end
-	if cb then
-		cb(false)
 	end
 end
 

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -277,7 +277,7 @@ InventoryService.usedWeapon = function(id, _used, _used2)
 	end)
 end
 
-InventoryService.subItem = function(target, invId, itemId, amount)
+InventoryService.subItem = function(target, invId, itemId, amount, cb)
 	local _source = target
 	local sourceCharacter = Core.getUser(_source).getUsedCharacter
 	local identifier = sourceCharacter.identifier
@@ -303,8 +303,14 @@ InventoryService.subItem = function(target, invId, itemId, amount)
 				else
 					DbService.SetItemAmount(item:getOwner(), itemId, item:getCount())
 				end
+				if cb then 
+					cb(true) 
+				end
 			end
 		end
+	end
+	if cb then
+		cb(false)
 	end
 end
 
@@ -995,6 +1001,9 @@ InventoryService.TakeFromCustom = function(obj)
 	else
 		InventoryAPI.canCarryItem(_source, item.name, amount, function (res)
 			if res then
+				if amount > item.count then
+					return
+				end
 				InventoryService.subItem(_source, invId, item.id, amount)
 				InventoryService.addItem(_source, "default", item.name, amount, item.metadata, function (itemAdded)
 					if itemAdded == nil then


### PR DESCRIPTION
**How the bug occurs and how to replicate:**

- CustomInventory: 1x "Item A", this item has a limit of 25 units in the user inventory
- User takes 25x "Item A"
- The subItem function will not allow subtracting this quantity, since it's above the item count
- However, this is not blocking the execution of the function, which leads then to still call addItems
- The user now has 25x "Item A"
- CustomInventory has still 1x "Item A" since, of course, it hasn't subtracted items.

**The fix:**
The fix was pretty straightforward, it was just a matter of checking whether the amount requested wasn't higher than the amount available. 
