### PR TITLE
Add whitelist mode for custom inventories

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -8,7 +8,8 @@ CustomInventoryInfos = {
 		shared = false,
 		---@type table<string, integer>
 		limitedItems = {},
-		ignoreItemStackLimit = false
+		ignoreItemStackLimit = false,
+		whitelistItems = false
 	}
 }
 
@@ -982,10 +983,11 @@ InventoryAPI.onNewCharacter = function(playerId)
 	end
 end
 
-InventoryAPI.registerInventory = function(id, name, limit, acceptWeapons, shared, ignoreItemStackLimit)
+InventoryAPI.registerInventory = function(id, name, limit, acceptWeapons, shared, ignoreItemStackLimit, whitelistItems)
 	limit = limit and limit or -1
 	ignoreItemStackLimit = ignoreItemStackLimit and ignoreItemStackLimit or false
 	acceptWeapons = acceptWeapons == nil and true or acceptWeapons
+	whitelistItems = whitelistItems and whitelistItems or false
 	shared = shared and shared or false
 	if CustomInventoryInfos[id] then
 		return
@@ -997,6 +999,7 @@ InventoryAPI.registerInventory = function(id, name, limit, acceptWeapons, shared
 		acceptWeapons = acceptWeapons,
 		shared = shared,
 		ignoreItemStackLimit = ignoreItemStackLimit,
+		whitelistItems = whitelistItems,
 		limitedItems = {}
 	}
 	UsersInventories[id] = {}

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -857,6 +857,8 @@ InventoryService.canStoreWeapon = function(identifier, charIdentifier, invId, na
 		if weaponCount > invData.limitedItems[name] then
 			return false
 		end
+	elseif invData.whitelistItems then
+		return false
 	end
 	return true
 end
@@ -884,6 +886,23 @@ InventoryService.canStoreItem = function(identifier, charIdentifier, invId, name
 			local totalAmount = amount + itemCount
 
 			if totalAmount > invData.limitedItems[name] then
+				return false
+			end
+		else if amount > invData.limitedItems[name] then
+			return false
+		end
+		return true
+	elseif invData.whitelistItems then
+		return false
+	end
+
+	if not invData.ignoreItemStackLimit then
+		local item = SvUtils.FindItemByNameAndMetadata(invId, identifier, name, metadata)
+
+		if item ~= nil then
+			local totalCount = item:getCount() + amount
+
+			if totalCount > item:getLimit() then
 				return false
 			end
 		end

--- a/vorpInventoryApi.lua
+++ b/vorpInventoryApi.lua
@@ -1,8 +1,8 @@
 exports('vorp_inventoryApi',function()
     local self = {}
 
-    self.registerInventory = function(id, name, limit, acceptWeapons, shared, ignoreItemStackLimit)
-        TriggerEvent("vorpCore:registerInventory", id, name, limit, acceptWeapons, shared, ignoreItemStackLimit)
+    self.registerInventory = function(id, name, limit, acceptWeapons, shared, ignoreItemStackLimit, whitelistItems)
+        TriggerEvent("vorpCore:registerInventory", id, name, limit, acceptWeapons, shared, ignoreItemStackLimit, whitelistItems)
     end
 
     self.removeInventory = function(id)


### PR DESCRIPTION
Adding a whitelistItems paramater to the registerInventory API function.
Default value is False.

When this parameter is set to True, only the limited items will be taken into account when moving items to inventory.
Need Some testing.