### PR TITLE
Search for secondary Inventory + Transaction loader added to giveWeapons

### DIFF
--- a/client/services/NUIService.lua
+++ b/client/services/NUIService.lua
@@ -14,6 +14,10 @@ end)
 
 NUIService.ReloadInventory = function(inventory)
     local payload = json.decode(inventory)
+	if payload.itemList == '[]' then
+		payload.itemList = {}
+	end
+
     for _, item in pairs(payload.itemList) do
         if item.type == "item_weapon" then
             item.label = Utils.GetWeaponLabel(item.name)
@@ -255,7 +259,7 @@ NUIService.NUISetNearPlayers = function(obj, nearestPlayers)
 	local isAnyPlayerFound = #nearestPlayers > 0
 
 	if next(nearestPlayers) == nil then
-		print("No Near Players")
+		TriggerEvent('vorp:TipRight', "No Players Near By", 5000)
 		return
 	end
 	

--- a/html/css/ui.min.css
+++ b/html/css/ui.min.css
@@ -350,7 +350,7 @@ body {
     
 }
 
-.controls #search {
+.controls #search, .controls #secondarysearch {
     float: left;
     width: 40%;
     color: #ffffff;
@@ -393,7 +393,7 @@ button {
     font-size: 19px;
 }
 
-input#search {
+input#search, input#secondarysearch {
     background: transparent;
     border: none;
     float: left;
@@ -410,19 +410,15 @@ input#search {
     background-size: 200px 90px;
 }
 
-input#search::-webkit-input-placeholder {
+input#search::-webkit-input-placeholder, input#secondarysearch::-webkit-input-placeholder {
     color: #ffffff;
 }
 
-input#search:-moz-placeholder {
+input#search:-moz-placeholder, input#secondarysearch:-moz-placeholder {
     color: #ffffff;
 }
 
-input#search::-moz-placeholder {
-    color: #ffffff;
-}
-
-input#search:-ms-input-placeholder {
+input#search:-ms-input-placeholder, input#secondarysearch:-ms-input-placeholder {
     color: #ffffff;
 }
 

--- a/html/js/utils.js
+++ b/html/js/utils.js
@@ -49,6 +49,22 @@ function hideSecondaryCapacity() {
 }
 
 function initiateSecondaryInventory(id, title, capacity) {
+    $("#secondInventoryHud").append(
+        `<div class='controls'><div class='controls-center'><input type='text' id='secondarysearch' placeholder='Search'/></div></div>`
+    );
+
+    $("#secondarysearch").bind('input', function () {
+        searchFor = $("#secondarysearch").val().toLowerCase();
+        $("#secondInventoryElement .item").each(function () {
+            label = $(this).data("label").toLowerCase();
+            if (label.indexOf(searchFor) < 0) {
+                $(this).hide();
+            } else {
+                $(this).show();
+            }
+        });
+    });
+    
     $("#secondInventoryHud").fadeIn();
     secondarySetTitle(title);
 

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -619,12 +619,15 @@ end
 InventoryService.GiveWeapon = function(weaponId, target)
 	local _source = source
 	if not SvUtils.InProcessing(_source) then
+		TriggerClientEvent("vorp_inventory:transactionStarted", _source)
 		SvUtils.ProcessUser(_source)
 		local _target = target
 
 		if UsersWeapons["default"][weaponId] ~= nil then
 			InventoryAPI.giveWeapon2(_target, weaponId, _source)
 		end
+
+		TriggerClientEvent("vorp_inventory:transactionCompleted", _source)
 		SvUtils.Trem(_source)
 	end
 end


### PR DESCRIPTION
Too tired, so I will test the giveweapon transaction loading modal in the morning.  

**What this changed**
-  🆕 Search bar for secondary inventories. They can get pretty long (this includes banks, storages, etc), so a search we think was much needed.
- 🆕 Transaction loader (same loading modal you get when giving items) will now apply to giving weapons as well
- Minor bug fix.