### PR TITLE
Potential fix for weapons that cannot be moved in custom invs

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -864,8 +864,6 @@ InventoryService.canStoreWeapon = function(identifier, charIdentifier, invId, na
 		end
 	elseif invData.whitelistItems then
 		return false
-	else -- reject weapon if not found in the list
-		return false
 	end
 	return true
 end
@@ -952,8 +950,6 @@ InventoryService.MoveToCustom = function(obj)
 
 	if item.type == "item_weapon" then
 		if CustomInventoryInfos[invId].acceptWeapons then -- if accept weapons
-
-
 			if InventoryService.canStoreWeapon(sourceIdentifier, sourceCharIdentifier, invId, item.name, amount) then
 				exports.oxmysql:execute("UPDATE loadout SET identifier = '',curr_inv = @invId WHERE charidentifier = @charid AND id = @weaponId;"
 					, {
@@ -969,6 +965,7 @@ InventoryService.MoveToCustom = function(obj)
 				TriggerClientEvent("vorpCoreClient:subWeapon", _source, item.id)
 				InventoryAPI.reloadInventory(_source, invId)
 			else
+				print('testa di cazzo #1')
 				TriggerClientEvent("vorp:TipRight", _source, _U("fullInventory"), 2000)
 			end
 		end


### PR DESCRIPTION
Weapons could not be moved to custom inventories if not in the limitedItems list, so if a limit was not specified (unlimited) they couldn't be moved at all.

Apparently, the fix does not break other stuff, it shouldn't interfere with whichever anti-duping system was implemented but I'd like to have it confirmed by someone who worked at it, just to make sure not to introduce new bugs :)

The specific line I edited should be part of an @outsider31000's commit.

I'm available for any further questions or clarifications.