### PR TITLE
Fix for weapons in custom inventories

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -1121,11 +1121,13 @@ InventoryService.TakeFromCustom = function(obj)
 				})
 				UsersWeapons[invId][item.id]:setCurrInv("default")
 				UsersWeapons["default"][item.id] = UsersWeapons[invId][item.id]
+				UsersWeapons["default"][item.id].propietary = sourceIdentifier
+				UsersWeapons["default"][item.id].charId = sourceCharIdentifier
 				UsersWeapons[invId][item.id] = nil
 
 				local weapon = UsersWeapons["default"][item.id]
 
-				TriggerClientEvent("vorpInventory:receiveWeapon", _source, item.id, weapon:getPropietary(), weapon:getName(),
+				TriggerClientEvent("vorpInventory:receiveWeapon", _source, item.id, sourceIdentifier, weapon:getName(),
 					weapon:getAllAmmo())
 				InventoryAPI.reloadInventory(_source, invId)
 				InventoryService.DiscordLogs(invId, item.name, amount, sourceName, "Take")


### PR DESCRIPTION
Fixed wrong handling of weapons taken from custom inventories causing players loosing their weapons on relog until next restart.

Problem was in charIds and propietaries not updated in server-side table UsersWeapons which has been leading to problem that on relog weapon wasn't added to players inventory on loading unless server is restarted.