### PR TITLE
Update inventoryApiService.lua

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -382,8 +382,8 @@ InventoryAPI.getItemContainingMetadata = function(player, itemName, metadata, cb
 		return
 	end
 
-	metadata = SharedUtils.MergeTables(svItem.metadata or {}, metadata or {})
 	local item = SvUtils.FindItemByNameAndContainingMetadata("default", identifier, itemName, metadata)
+	
 	if item then
 		cb(item)
 	else


### PR DESCRIPTION
Changes:
- Removed the table merge from the InventoryAPI#getItemContainingMetadata() function. The wrongly implemented merge caused the function to return no item due to merging the original item metadata and the argument passed within the function. Removing the SharedUtils#MergeTables() function fixed the issue, cause the item filter would use the correct metadata table passed to the function.