### PR TITLE
- Enhance inventory to allow adding more grades with the same job name

### DIFF
--- a/server/controllers/inventoryApiController.lua
+++ b/server/controllers/inventoryApiController.lua
@@ -97,8 +97,10 @@ RegisterServerEvent("vorpCore:setInventoryItemLimit")
 AddEventHandler("vorpCore:setInventoryItemLimit", InventoryAPI.setCustomInventoryItemLimit)
 
 AddEventHandler("vorp_inventory:Server:AddPermissionMoveToCustom", InventoryAPI.AddPermissionMoveToCustom)
+AddEventHandler("vorp_inventory:Server:RemovePermissionMoveToCustom", InventoryAPI.RemovePermissionMoveToCustom)
 
 AddEventHandler("vorp_inventory:Server:AddPermissionTakeFromCustom", InventoryAPI.AddPermissionTakeFromCustom)
+AddEventHandler("vorp_inventory:Server:RemovePermissionTakeFromCustom", InventoryAPI.RemovePermissionTakeFromCustom)
 
 AddEventHandler("vorp_inventory:Server:BlackListCustom", InventoryAPI.BlackListCustom)
 

--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -1107,7 +1107,42 @@ InventoryAPI.AddPermissionMoveToCustom = function(id, jobName, grade)
 		Log.print("AdPermsMoveTo  for [^3" .. jobName .. "^7] and grade [^3" .. grade .. "^7]")
 	end
 
-	CustomInventoryInfos[id].PermissionMoveTo[jobName] = grade -- create table with item name and count
+	if not CustomInventoryInfos[id].PermissionMoveTo[jobName] then
+		CustomInventoryInfos[id].PermissionMoveTo[jobName] = {}
+	end
+
+	for _, existingGrade in ipairs(CustomInventoryInfos[id].PermissionMoveTo[jobName]) do
+		if existingGrade == grade then
+			return -- dont add
+		end
+	end
+
+	table.insert(CustomInventoryInfos[id].PermissionMoveTo[jobName], grade) -- create table with item name and count
+end
+
+InventoryAPI.RemovePermissionMoveToCustom = function(id, jobName, grade)
+	if not CustomInventoryInfos[id] then
+		return -- dont add
+	end
+
+	if not jobName and not grade then
+		return -- dont add
+	end
+	if Config.DevMode then
+		Log.print("RemovePermsMoveTo  for [^3" .. jobName .. "^7] and grade [^3" .. grade .. "^7]")
+	end
+
+	if not CustomInventoryInfos[id].PermissionMoveTo[jobName] then
+		return -- dont add
+	end
+
+	local newPerms = {}
+	for _, currentGrade in ipairs(CustomInventoryInfos[id].PermissionMoveTo[jobName]) do
+		if grade ~= currentGrade then
+			table.insert(newPerms, currentGrade)
+		end
+	end
+	CustomInventoryInfos[id].PermissionMoveTo[jobName] = newPerms -- update table with item name and count
 end
 
 InventoryAPI.AddPermissionTakeFromCustom = function(id, jobName, grade)
@@ -1121,7 +1156,45 @@ InventoryAPI.AddPermissionTakeFromCustom = function(id, jobName, grade)
 	if Config.DevMode then
 		Log.print("AdPermsTakeFrom  for [^3" .. jobName .. "^7] and grade [^3" .. grade .. "^7]")
 	end
-	CustomInventoryInfos[id].PermissionTakeFrom[jobName] = grade -- create table with item name and count
+
+	if not CustomInventoryInfos[id].PermissionTakeFrom[jobName] then
+		CustomInventoryInfos[id].PermissionTakeFrom[jobName] = {}
+	end
+
+	for _, existingGrade in ipairs(CustomInventoryInfos[id].PermissionTakeFrom[jobName]) do
+		if existingGrade == grade then
+			return -- dont add
+		end
+	end
+
+	table.insert(CustomInventoryInfos[id].PermissionTakeFrom[jobName], grade) -- create table with item name and count
+end
+
+InventoryAPI.RemovePermissionTakeFromCustom = function(id, jobName, grade)
+	if not CustomInventoryInfos[id] then
+		return -- dont add
+	end
+
+	if not jobName and not grade then
+		return -- dont add
+	end
+
+	if Config.DevMode then
+		Log.print("AdPermsTakeFrom  for [^3" .. jobName .. "^7] and grade [^3" .. grade .. "^7]")
+	end
+
+	if not CustomInventoryInfos[id].PermissionTakeFrom[jobName] then
+		return -- dont add
+	end
+
+	local newPerms = {}
+	for _, currentGrade in ipairs(CustomInventoryInfos[id].PermissionTakeFrom[jobName]) do
+		if grade ~= currentGrade then
+			table.insert(newPerms, currentGrade)
+		end
+	end
+
+	CustomInventoryInfos[id].PermissionTakeFrom[jobName] = newPerms -- update table with item name and count
 end
 
 InventoryAPI.BlackListCustom = function(id, name)

--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -382,8 +382,8 @@ InventoryAPI.getItemContainingMetadata = function(player, itemName, metadata, cb
 		return
 	end
 
-	metadata = SharedUtils.MergeTables(svItem.metadata or {}, metadata or {})
 	local item = SvUtils.FindItemByNameAndContainingMetadata("default", identifier, itemName, metadata)
+	
 	if item then
 		cb(item)
 	else

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -960,10 +960,12 @@ InventoryService.DoesHavePermission = function(invId, job, grade, Table)
 	if not next(Table) then -- if empty allow anyone by default is empty
 		return true
 	end
-	for jobname, jobgrade in pairs(Table) do
+	for jobname, jobgrades in pairs(Table) do
 		if jobname == job then
-			if grade == jobgrade then
-				return true
+			for _, jobgrade in ipairs(jobgrades) do
+				if grade == jobgrade then
+					return true
+				end
 			end
 		end
 	end

--- a/vorpInventoryApi.lua
+++ b/vorpInventoryApi.lua
@@ -34,8 +34,15 @@ exports('vorp_inventoryApi', function()
         TriggerEvent("vorp_inventory:Server:AddPermissionMoveToCustom", ...)
     end
 
+    self.RemovePermissionMoveToCustom = function(...)
+        TriggerEvent("vorp_inventory:Server:RemovePermissionMoveToCustom", ...)
+    end
+
     self.AddPermissionTakeFromCustom = function(...)
         TriggerEvent("vorp_inventory:Server:AddPermissionTakeFromCustom", ...)
+    end
+    self.RemovePermissionTakeFromCustom = function(...)
+        TriggerEvent("vorp_inventory:Server:RemovePermissionTakeFromCustom", ...)
     end
 
     self.setInventoryItemLimit = function(id, itemName, limit)


### PR DESCRIPTION
We had the situation, that we need to allow more then one grade the permission to take from / move to.
As we recognized, that the current implementation only allows one grade per job (job is always overwritten), here is an enhancement to allow multiple grades for the same job name.

How it works?:
Use a table within [jobName], only add the grade if not already exists, loop the new table within permission check.

Also we implemented a new functionality to remove a permission.