### PR TITLE
fix: weapons are now loaded in resource start to fix a problem with shared inventories where weapons where not loaded correctly

### DIFF
--- a/server/server.lua
+++ b/server/server.lua
@@ -100,7 +100,7 @@ if Config.DevMode then
             local characterId = Core.getUser(source).getUsedCharacter
 
             TriggerClientEvent("vorp:SelectedCharacter", source, characterId)
-            LoadDatabase(charid)
+            LoadDatabase()
             -- If it's not a player, then it must be RCON, a resource, or the server console directly.
         else
             print("This command was executed by the server console, RCON client, or a resource.")

--- a/server/services/itemsDatabase.lua
+++ b/server/services/itemsDatabase.lua
@@ -17,8 +17,8 @@ UsersWeapons = {
 svItems = {}
 
 
-local function LoadDatabase(charid)
-	local result = MySQL.query.await('SELECT * FROM loadout WHERE charidentifier = ? ', { charid })
+local function LoadDatabase()
+	local result = MySQL.query.await('SELECT * FROM loadout')
 	if next(result) then
 		for _, db_weapon in pairs(result) do
 			if db_weapon.charidentifier then
@@ -63,18 +63,19 @@ local function LoadDatabase(charid)
 	end
 end
 
--- * ON PLAYER SPAWN LOAD ALL THEIR WEAPONS * --
-RegisterNetEvent("vorp:SelectedCharacter", function(source, character)
-	local _source = source
+-- * ON START LOAD ALL WEAPONS * --
+AddEventHandler("onResourceStart", function(resourceName)
+	if (GetCurrentResourceName() ~= resourceName) then
+		return
+	end
 
 	if Config.DevMode then
 		return print(
 			"^1[DEV] ^3Inventory ^7| ^1WARNING: ^7You are in dev mode, dont use this in production live servers")
 	end
 
-	local charid = character.charIdentifier
 	CreateThread(function()
-		LoadDatabase(charid)
+		LoadDatabase()
 	end)
 end)
 
@@ -109,9 +110,6 @@ end)
 
 if Config.DevMode then
 	RegisterNetEvent("DEV:loadweapons", function()
-		local _source = source
-		local character = Core.getUser(_source).getUsedCharacter
-		local charid = character.charIdentifier
-		LoadDatabase(charid)
+		LoadDatabase()
 	end)
 end


### PR DESCRIPTION
This would be a possible fix for #179 where all loadouts are loaded once at resource start to mitigate problems with shared inventories.

Previously, the loadouts were loaded on player login, which resulted in missing weapons when using shared inventories, as the weapons of offline players would not be loaded in the first place after a server restart.

This is now solved by loading every loadout on server start.