### PR TITLE
chore: lower number of calls to the PlayerPedId

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -82,8 +82,9 @@ AddEventHandler("vorpinventory:loaded", function()
         Wait(100)
     end
     local playerammo = playerammoinfo["ammo"]
-    for k,v in pairs(playerammo) do 
-        SetPedAmmoByType(PlayerPedId(), GetHashKey(k), v)
+    local playerPedId = PlayerPedId();
+    for k, v in pairs(playerammo) do
+        SetPedAmmoByType(playerPedId, GetHashKey(k), v)
     end
     SendNUIMessage({
         action = "updateammo",
@@ -103,10 +104,11 @@ end)
 
 RegisterNetEvent("vorpinventory:setammotoped")
 AddEventHandler("vorpinventory:setammotoped", function(ammo)
-    Citizen.InvokeNative(0xF25DF915FA38C5F3, PlayerPedId(), 1, 1)
-    Citizen.InvokeNative(0x1B83C0DEEBCBB214, PlayerPedId())
+    local playerPedId = PlayerPedId();
+    Citizen.InvokeNative(0xF25DF915FA38C5F3, playerPedId, 1, 1)
+    Citizen.InvokeNative(0x1B83C0DEEBCBB214, playerPedId)
     for k, v in pairs(ammo) do
-        SetPedAmmoByType(PlayerPedId(), GetHashKey(k), v)
+        SetPedAmmoByType(playerPedId, GetHashKey(k), v)
     end
 end)
 
@@ -134,8 +136,9 @@ Citizen.CreateThread(function()
     while true do
         Wait(500)
         if loaded then
-            local isArmed = Citizen.InvokeNative(0xCB690F680A3EA971, PlayerPedId(), 4)
-            local wephash = Citizen.InvokeNative(0x8425C5F057012DAB, PlayerPedId())
+            local playerPedId = PlayerPedId()
+            local isArmed = Citizen.InvokeNative(0xCB690F680A3EA971, playerPedId, 4)
+            local wephash = Citizen.InvokeNative(0x8425C5F057012DAB, playerPedId)
             local ismelee = Citizen.InvokeNative(0x959383DCD42040DA, wephash)
             if (isArmed or GetWeapontypeGroup(wephash) == 1548507267) and not ismelee then
                 getammoinfo = true
@@ -149,7 +152,7 @@ Citizen.CreateThread(function()
                 if ammotypes ~= nil and playerammo ~= nil then
                     for k, v in pairs(ammotypes) do
                         if contains(playerammo, v) then
-                            local qt = Citizen.InvokeNative(0x39D22031557946C1, PlayerPedId(), GetHashKey(v))
+                            local qt = Citizen.InvokeNative(0x39D22031557946C1, playerPedId, GetHashKey(v))
                             if not qt or ((GetWeapontypeGroup(wephash) == 1548507267 or GetWeapontypeGroup(wephash) == -1241684019) and qt == 1) then -- an issue occurs where when the player fires their last throwable this loop stops since the player auto switches to melee and it never registers that they used the last of their ammo, creating a problem where the player will always have 1 throwable left even after they have used it. to combat this the player is considered out of ammo if they only have 1 ammo left
                                 qt = 0
                             end

--- a/client/models/WeaponClass.lua
+++ b/client/models/WeaponClass.lua
@@ -37,6 +37,8 @@ local function addWeapon(weapon, slot, id)
 			slot = 1
 		end
 	end
+
+	local playerPedId = PlayerPedId()
 	local weaponHash = joaat(weapon)
 	local sHash = "SLOTID_WEAPON_" .. tostring(slot)
 	local reason = joaat("ADD_REASON_DEFAULT")
@@ -94,9 +96,9 @@ local function addWeapon(weapon, slot, id)
 		return false
 	end
 
-	Citizen.InvokeNative(0x12FB95FE3D579238, PlayerPedId(), itemData:Buffer(), true, slot, false, false)
+	Citizen.InvokeNative(0x12FB95FE3D579238, playerPedId, itemData:Buffer(), true, slot, false, false)
 	if move then
-		Citizen.InvokeNative(0x12FB95FE3D579238, PlayerPedId(), equippedWeapons[1].guid, true, 1, false, false)
+		Citizen.InvokeNative(0x12FB95FE3D579238, playerPedId, equippedWeapons[1].guid, true, 1, false, false)
 		TriggerServerEvent("syn_weapons:applyDupeTint", id, itemData:Buffer(), weaponHash)
 	end
 	if id then
@@ -123,6 +125,8 @@ function Weapon:RemoveWeaponFromPed()
 	local isWeaponOneHanded = Citizen.InvokeNative(0xD955FEE4B87AFA07, joaat(self.name))
 	local move = false
 
+	local playerPedId = PlayerPedId()
+
 	if isWeaponAGun and isWeaponOneHanded then
 		for k, v in pairs(equippedWeapons) do
 			if v.id == self.id then
@@ -145,9 +149,9 @@ function Weapon:RemoveWeaponFromPed()
 			return false
 		end
 		moveInventoryItem(inventoryId, equippedWeapons[1].guid, weaponItem:Buffer(), 0)
-		Citizen.InvokeNative(0x12FB95FE3D579238, PlayerPedId(), equippedWeapons[1].guid, true, 0, false, false)
+		Citizen.InvokeNative(0x12FB95FE3D579238, playerPedId, equippedWeapons[1].guid, true, 0, false, false)
 	else
-		RemoveWeaponFromPed(PlayerPedId(), joaat(self.name), true, 0)
+		RemoveWeaponFromPed(playerPedId, joaat(self.name), true, 0)
 	end
 end
 
@@ -157,20 +161,22 @@ function Weapon:equipwep()
 	local isWeaponAGun = Citizen.InvokeNative(0x705BE297EEBDB95D, joaat(self.name))
 	local isWeaponOneHanded = Citizen.InvokeNative(0xD955FEE4B87AFA07, joaat(self.name))
 
+	local playerPedId = PlayerPedId()
+
 	if isWeaponMelee or isWeaponThrowable then
-		GiveDelayedWeaponToPed(PlayerPedId(), joaat(self.name), 0, true, 0)
+		GiveDelayedWeaponToPed(playerPedId, joaat(self.name), 0, true, 0)
 	else
 		if self.used2 then
 			if isWeaponAGun and isWeaponOneHanded then
 				addWeapon(self.name, 1, self.id)
 			else
-				local _, weaponHash = GetCurrentPedWeapon(PlayerPedId(), false, 0, false)
-				Citizen.InvokeNative(0x5E3BDDBCB83F3D84, PlayerPedId(), weaponHash, 1, 1, 1, 2, false, 0.5, 1.0,
+				local _, weaponHash = GetCurrentPedWeapon(playerPedId, false, 0, false)
+				Citizen.InvokeNative(0x5E3BDDBCB83F3D84, playerPedId, weaponHash, 1, 1, 1, 2, false, 0.5, 1.0,
 					752097756, 0, true, 0.0)
-				Citizen.InvokeNative(0x5E3BDDBCB83F3D84, PlayerPedId(), joaat(self.name), 1, 1, 1, 3, false, 0.5,
+				Citizen.InvokeNative(0x5E3BDDBCB83F3D84, playerPedId, joaat(self.name), 1, 1, 1, 3, false, 0.5,
 					1.0, 752097756, 0, true, 0.0)
-				Citizen.InvokeNative(0xADF692B254977C0C, PlayerPedId(), weaponHash, 0, 1, 0, 0)
-				Citizen.InvokeNative(0xADF692B254977C0C, PlayerPedId(), joaat(self.name), 0, 0, 0, 0)
+				Citizen.InvokeNative(0xADF692B254977C0C, playerPedId, weaponHash, 0, 1, 0, 0)
+				Citizen.InvokeNative(0xADF692B254977C0C, playerPedId, joaat(self.name), 0, 0, 0, 0)
 			end
 		else
 			if isWeaponAGun and isWeaponOneHanded then
@@ -182,15 +188,16 @@ function Weapon:equipwep()
 						ammoCount = 1
 					end
 				end
-				GiveDelayedWeaponToPed(PlayerPedId(), joaat(self.name), ammoCount, true, 0)
+				GiveDelayedWeaponToPed(playerPedId, joaat(self.name), ammoCount, true, 0)
 			end
 		end
 	end
 end
 
 function Weapon:loadComponents()
+	local playerPedId = PlayerPedId()
 	for _, value in pairs(self.components) do
-		Citizen.InvokeNative(0x74C9090FDD1BB48E, PlayerPedId(), joaat(value), joaat(self.name), true)
+		Citizen.InvokeNative(0x74C9090FDD1BB48E, playerPedId, joaat(value), joaat(self.name), true)
 	end
 end
 

--- a/client/services/PickupsService.lua
+++ b/client/services/PickupsService.lua
@@ -8,7 +8,7 @@ PickupsService.CreateObject = function(model, position)
 	local objectHash = GetHashKey(model)
 
 	if not Citizen.InvokeNative(0x1283B8B89DD5D1B6, objectHash) then -- HasModelLoaded
-		Citizen.InvokeNative(0xFA28FE3A6246FC30, objectHash)      -- RequestModel
+		Citizen.InvokeNative(0xFA28FE3A6246FC30, objectHash)          -- RequestModel
 	end
 
 	while not Citizen.InvokeNative(0x1283B8B89DD5D1B6, objectHash) do -- HasModelLoaded
@@ -16,12 +16,12 @@ PickupsService.CreateObject = function(model, position)
 	end
 
 	local entityHandle = Citizen.InvokeNative(0x509D5878EB39E842, objectHash, position.x, position.y, position.z, true,
-		true, true)                                                  -- CreateObject
+		true, true)                                                      -- CreateObject
 
-	Citizen.InvokeNative(0x58A850EAEE20FAA3, entityHandle)           -- PlaceObjectOnGroundProperly
+	Citizen.InvokeNative(0x58A850EAEE20FAA3, entityHandle)             -- PlaceObjectOnGroundProperly
 	Citizen.InvokeNative(0xDC19C288082E586E, entityHandle, true, false) -- SetEntityAsMissionEntity
-	Citizen.InvokeNative(0x7D9EFB7AD6B19754, entityHandle, true)     -- FreezeEntityPosition
-	Citizen.InvokeNative(0x7DFB49BCDB73089A, entityHandle, true)     -- SetPickupLight
+	Citizen.InvokeNative(0x7D9EFB7AD6B19754, entityHandle, true)       -- FreezeEntityPosition
+	Citizen.InvokeNative(0x7DFB49BCDB73089A, entityHandle, true)       -- SetPickupLight
 	Citizen.InvokeNative(0xF66F820909453B8C, entityHandle, false, true) -- SetEntityCollision
 
 	SetModelAsNoLongerNeeded(objectHash)
@@ -200,6 +200,7 @@ PickupsService.removePickupClient = function(entityHandle)
 end
 
 PickupsService.playerAnim = function(obj)
+	local playerPedId = PlayerPedId()
 	local animDict = "amb_work@world_human_box_pickup@1@male_a@stand_exit_withprop"
 	Citizen.InvokeNative(0xA862A2AD321F94B4, animDict)
 
@@ -207,12 +208,12 @@ PickupsService.playerAnim = function(obj)
 		Wait(10)
 	end
 
-	Citizen.InvokeNative(0xEA47FE3719165B94, PlayerPedId(), animDict, "exit_front", 1.0, 8.0, -1, 1, 0, false, false,
+	Citizen.InvokeNative(0xEA47FE3719165B94, playerPedId, animDict, "exit_front", 1.0, 8.0, -1, 1, 0, false, false,
 		false)
 	Wait(1200)
 	PlaySoundFrontend("CHECKPOINT_PERFECT", "HUD_MINI_GAME_SOUNDSET", true, 1)
 	Wait(1000)
-	Citizen.InvokeNative(0xE1EF3C1216AFF2CD, PlayerPedId())
+	Citizen.InvokeNative(0xE1EF3C1216AFF2CD, playerPedId)
 end
 
 PickupsService.DeadActions = function()
@@ -225,6 +226,7 @@ end
 
 PickupsService.dropAllPlease = function()
 	Wait(200)
+	local playerPedId = PlayerPedId()
 
 	if Config.UseClearAll then
 		return
@@ -275,7 +277,7 @@ PickupsService.dropAllPlease = function()
 
 				if currentWeapon:getUsed() then
 					currentWeapon:setUsed(false)
-					RemoveWeaponFromPed(PlayerPedId(), GetHashKey(currentWeapon:getName()), true, 0)
+					RemoveWeaponFromPed(playerPedId, GetHashKey(currentWeapon:getName()), true, 0)
 				end
 
 				UserWeapons[index] = nil
@@ -294,7 +296,7 @@ PickupsService.OnWorldPickup = function()
 		return
 	end
 
-	local playerPed = PlayerPedId()
+	local playerPedId = PlayerPedId()
 	local pickupsInRange = {}
 
 	for key, value in pairs(WorldPickups) do
@@ -310,8 +312,8 @@ PickupsService.OnWorldPickup = function()
 
 	for _, pickup in pairs(pickupsInRange) do
 		if pickup:Distance() <= 1.2 then
-			Citizen.InvokeNative(0x69F4BE8C8CC4796C, playerPed, pickup.entityId, 3000, 2048, 3) -- TaskLookAtEntity
-			local isDead = IsEntityDead(playerPed)
+			Citizen.InvokeNative(0x69F4BE8C8CC4796C, playerPedId, pickup.entityId, 3000, 2048, 3) -- TaskLookAtEntity
+			local isDead = IsEntityDead(playerPedId)
 
 
 			pickup.prompt:SetVisible(not isDead)

--- a/client/services/UtilityService.lua
+++ b/client/services/UtilityService.lua
@@ -1,37 +1,39 @@
 Utils = {}
 
-Utils.FindItemByNameAndMetadata = function (identifier, name, metadata)
-    if UserInventory == nil then
-        return nil
-    end
-    
-    for _, item in pairs(UserInventory) do
-        if name == item:getName() and SharedUtils.Table_equals(metadata, item:getMetadata()) then
-            return item
-        end
-    end
-    return nil
+Utils.FindItemByNameAndMetadata = function(identifier, name, metadata)
+	if UserInventory == nil then
+		return nil
+	end
+
+	for _, item in pairs(UserInventory) do
+		if name == item:getName() and SharedUtils.Table_equals(metadata, item:getMetadata()) then
+			return item
+		end
+	end
+	return nil
 end
 
 Utils.cleanAmmo = function(id)
+	local playerPedId = PlayerPedId()
 	if next(UserWeapons[id]) ~= nil then
-		SetPedAmmo(PlayerPedId(), GetHashKey(UserWeapons[id]:getName()), 0)
+		SetPedAmmo(playerPedId, GetHashKey(UserWeapons[id]:getName()), 0)
 
 		for _, ammo in pairs(UserWeapons[id]:getAllAmmo()) do
-			SetPedAmmoByType(PlayerPedId(), GetHashKey(_), 0)
+			SetPedAmmoByType(playerPedId, GetHashKey(_), 0)
 		end
 	end
 end
 
 Utils.useWeapon = function(id)
+	local playerPedId = PlayerPedId()
 	if UserWeapons[id]:getUsed2() then
 		local weaponHash = GetHashKey(UserWeapons[id]:getName())
-		GiveWeaponToPed_2(PlayerPedId(), weaponHash, 0, true, true, 3, false, 0.5, 1.0, 752097756, false, 0, false)
-		SetCurrentPedWeapon(PlayerPedId(), weaponHash, 0, 0, 0, 0)
-		SetPedAmmo(PlayerPedId(), weaponHash, 0)
+		GiveWeaponToPed_2(playerPedId, weaponHash, 0, true, true, 3, false, 0.5, 1.0, 752097756, false, 0, false)
+		SetCurrentPedWeapon(playerPedId, weaponHash, 0, 0, 0, 0)
+		SetPedAmmo(playerPedId, weaponHash, 0)
 
 		for _, ammo in pairs(UserWeapons[id]:getAllAmmo()) do
-			SetPedAmmoByType(PlayerPedId, GetHashKey(_), ammo)
+			SetPedAmmoByType(playerPedId, GetHashKey(_), ammo)
 			if Config.Debug then
 				print(GetHashKey(_) .. ": " .. _ .. " " .. ammo)
 			end
@@ -42,13 +44,14 @@ Utils.useWeapon = function(id)
 end
 
 Utils.oldUseWeapon = function(id)
+	local playerPedId = PlayerPedId()
 	local weaponHash = GetHashKey(UserWeapons[id]:getName())
 
-	GiveWeaponToPed_2(PlayerPedId(), weaponHash, 0, true, true, 2, false, 0.5, 1.0, 752097756, false, 0, false)
-	SetCurrentPedWeapon(PlayerPedId(), weaponHash, 0, 1, 0, 0)
-	SetPedAmmo(PlayerPedId(), weaponHash, 0)
+	GiveWeaponToPed_2(playerPedId, weaponHash, 0, true, true, 2, false, 0.5, 1.0, 752097756, false, 0, false)
+	SetCurrentPedWeapon(playerPedId, weaponHash, 0, 1, 0, 0)
+	SetPedAmmo(playerPedId, weaponHash, 0)
 	for type, amount in pairs(UserWeapons[id]:getAllAmmo()) do
-		SetPedAmmoByType(PlayerPedId(), GetHashKey(type), amount)
+		SetPedAmmoByType(playerPedId, GetHashKey(type), amount)
 		if Config.Debug then
 			print(GetHashKey(type) .. ": " .. type .. " " .. amount)
 		end


### PR DESCRIPTION
Saw a lot of places where `PlayerPedId()` native was being called in loops, this is better set to a field in the function so its only called once and will improve performance as its unlikely the PlayerPedId will change while these methods are running.

This also contains a fix to `Utils.useWeapon` as it wasn't using the `PlayerPedId()` native correctly.