### PR TITLE
fix: use charidentifier instead of indentifier as item owner for custom inventories

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -1436,7 +1436,7 @@ function InventoryAPI.openInventory(player, id)
 			triggerAndReloadInventory()
 		else
 			DBService.GetInventory(charid, id, function(inventory)
-				UsersInventories[id][identifier] = createCharacterInventoryFromDB(inventory, identifier)
+				UsersInventories[id][identifier] = createCharacterInventoryFromDB(inventory, charid)
 				triggerAndReloadInventory()
 			end)
 		end


### PR DESCRIPTION
Hello,
I traced back an issue with personal custom inventories db entries not updating correctly when moving items from the own inventory to a stack of existing items in the personal custom inventory. In our use case we also use a script to manipulate the items in the inventory over time, which may explain why it is working in most normal use case.

This line of code is the root of the bug.
https://github.com/VORPCORE/vorp_inventory-lua/blob/38e958fc26a9d69082d1c124a0801e0a81300232/server/services/inventoryApiService.lua#L1439
it loads the inventory with the identifier as the owner, instead of the charidentifier. 

This resulting later in an error by calling `DBService.SetItemAmount(item:getOwner(), item:getId(), item:getCount())` in `InventoryService.addItem` 
https://github.com/VORPCORE/vorp_inventory-lua/blob/38e958fc26a9d69082d1c124a0801e0a81300232/server/services/inventoryService.lua#L393
with the identifier as the items owner instead of the charidentifier, the next step at DBService.SetItemAmount 
https://github.com/VORPCORE/vorp_inventory-lua/blob/38e958fc26a9d69082d1c124a0801e0a81300232/server/services/DbService.lua#L42
results in a faulty DB query because the DB expects the charidentifier as an INT but gets the steam identifier as a string.


As the DB queries have no error handling, the occurrence of this error cannot be recognised immediately. Also, the values in the NUI are updated correctly, so from a user perspective everything seems to work fine.  

This can be tested by replacing the function `DBService.SetItemAmount` with this code, adding debug messages:
```lua
function DBService.SetItemAmount(sourceCharIdentifier, itemCraftedId, amount)

    MySQL.update(
        "UPDATE character_inventories SET amount = @amount WHERE character_id = @charid AND item_crafted_id = @itemid;"
        , {
            ['amount'] = tonumber(amount),
            ['charid'] = tonumber(sourceCharIdentifier),
            ['itemid'] = tonumber(itemCraftedId)
        }, function (res)
            print(string.format("[DBService.SetItemAmount] UPDATE character_inventories SET amount = %s WHERE character_id = %s AND item_crafted_id = %s;", amount, sourceCharIdentifier, itemCraftedId))
            print("[DBService.SetItemAmount] result: " .. json.encode(res))
        end)
end
```

The output will be something like this:
```
[script:vorp_inventor] [DBService.SetItemAmount] UPDATE character_inventories SET amount = 8 WHERE character_id = 721 AND item_crafted_id = 1657860;
[script:vorp_inventor] [DBService.SetItemAmount] result: 1
[script:vorp_inventor] [DBService.SetItemAmount] UPDATE character_inventories SET amount = 4 WHERE character_id = steam:11000010000ffff AND item_crafted_id = 1657857;
[script:vorp_inventor] [DBService.SetItemAmount] result: 0
```
Where `1657860` is the item in the inventory that is tried to be moved to the custom inventory and `1657857` is the existing stack. 
`result: 0` indicates that no entries in the db are changed because the character_id is a steam identifier.