### PR TITLE
fix: using charidentifier of item instead of identifier as owner

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -1436,7 +1436,7 @@ function InventoryAPI.openInventory(player, id)
 			triggerAndReloadInventory()
 		else
 			DBService.GetInventory(charid, id, function(inventory)
-				UsersInventories[id][identifier] = createCharacterInventoryFromDB(inventory, identifier)
+				UsersInventories[id][identifier] = createCharacterInventoryFromDB(inventory)
 				triggerAndReloadInventory()
 			end)
 		end


### PR DESCRIPTION
closes #211 

As explained in #208 this is the pull request to solve the issue.

Existing items in non-shared inventories are loaded with the identifier of the player opening the inventory the first time. This should not be the identifier, as the db query expects the owner to be a charidentifier. The paramter is optional, and it would be best to not specify the 2nd parameter for `createCharacterInventoryFromDB` and just use the item owner of the item from the db instead of overwriting it on the first inventory load. (thanks to @ZambrOvosky for the hint)

This pull request is the altered version of the initial one. It is tested on a medium-sized server (~60 players online at the same time) for a day now. 