### PR TITLE
Allow scripts to register multiple callback on item use and unregister them

### DIFF
--- a/server/services/UtiliyService.lua
+++ b/server/services/UtiliyService.lua
@@ -223,6 +223,14 @@ function SvUtils.filterWeaponsSerialNumber(name)
     return true
 end
 
+--- generate a unique random id
+---@return string
+function SvUtils.GenerateUniqueID()
+	local time = os.time()
+	local randomNum = math.random(1000000, 9999999)
+	return tostring(time) .. tostring(randomNum)
+end
+
 --- generate a unique serial number
 ---@return string
 function SvUtils.GenerateSerialNumber(name)

--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -37,7 +37,7 @@ CustomInventoryInfos = {
 	}
 }
 
----@type table<string,function> table of Registered items
+---@type table<string, table<string, function>> table of Registered items
 UsableItemsFunctions = {}
 
 allplayersammo = {}
@@ -160,6 +160,7 @@ exports("getUserInventoryItems", InventoryAPI.getInventory)
 --- register usable item
 ---@param name string item name
 ---@param cb function callback
+---@return string
 function InventoryAPI.registerUsableItem(name, cb)
 	if Config.Debug then
 		SetTimeout(9000, function()
@@ -167,10 +168,32 @@ function InventoryAPI.registerUsableItem(name, cb)
 		end)
 	end
 
-	UsableItemsFunctions[name] = cb
+	local callbackId = SvUtils.GenerateUniqueID()
+	UsableItemsFunctions[name][callbackId] = cb
+
+	return callbackId
 end
 
 exports("registerUsableItem", InventoryAPI.registerUsableItem)
+
+--- remove callback for item
+---@param name string item name
+---@param cbId string id generated when registering the item callback
+function InventoryAPI.unRegisterUsableItem(name, cbId)
+	if Config.Debug then
+		SetTimeout(9000, function()
+			Log.print("Callback[^3" .. cbId .. "^7] for item[^3" .. name .. "^7] ^2UnRegistered!^7")
+		end)
+	end
+
+	if cbId == nil then
+		return
+	end
+
+	UsableItemsFunctions[name][cbId] = nil
+end
+
+exports("unRegisterUsableItem", InventoryAPI.unRegisterUsableItem)
 
 --- get user weapon
 ---@param player number player source

--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -169,6 +169,11 @@ function InventoryAPI.registerUsableItem(name, cb)
 	end
 
 	local callbackId = SvUtils.GenerateUniqueID()
+
+	if not UsableItemsFunctions[name] then
+		UsableItemsFunctions[name] = {}
+	end
+
 	UsableItemsFunctions[name][callbackId] = cb
 
 	return callbackId

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -56,9 +56,12 @@ function InventoryService.UseItem(itemName, itemId, args)
 				item = itemArgs,
 				args = args
 			}
-			local success, result = pcall(UsableItemsFunctions[itemName], arguments)
-			if not success then
-				print("Function call failed with error:", result)
+
+			for _, cb in pairs(UsableItemsFunctions[itemName]) do
+				local success, result = pcall(cb, arguments)
+				if not success then
+					print("Function call failed with error:", result)
+				end
 			end
 		end
 	end
@@ -721,14 +724,8 @@ function InventoryService.onPickupGold(obj)
 	end
 end
 
-local function generateUniqueID()
-	local time = os.time()
-	local randomNum = math.random(1000000, 9999999)
-	return tostring(time) .. tostring(randomNum)
-end
-
 local function shareData(data)
-	local uid = generateUniqueID()
+	local uid = SvUtils.GenerateUniqueID()
 	ItemUids[uid] = uid
 
 	ItemPickUps[uid] = {

--- a/server/types/types.lua
+++ b/server/types/types.lua
@@ -33,7 +33,13 @@ function exports.vorp_inventory:getUserInventoryItems(source, callback) end
 
 ---@param item string item name
 ---@param callback fun(item:table)
+---@return string the callbackId to be used to cancel the callback
 function exports.vorp_inventory:registerUsableItem(item, callback) end
+
+--- remove callback for item
+---@param name string item name
+---@param callbackId string id generated when registering the item callback
+function InventoryAPI.unRegisterUsableItem(name, callbackId) end
 
 --- get user inventory weapon
 ---@param source number player id


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

### Motive for This Pull Request
I needed to register multiples callback for the same item inside of my script. Instead of just updating my version of vorp_inventory, I think it could be better to share this little update with everyone.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
The more you add scripts to your server, the more there is chance for two scripts to register a callback for the exact same item, and create a conflict.

In other hand, scripts are actually limited by the fact that, after a callback has been registered, there is not possible way to remove it, other that coding a ignore logic inside the callback.

These changes aim to provide more possibility of algorithm for the developer and a fix avoiding cross script conflict hard to debug.

### Explain the necessity of these changes and how they will impact the framework or its users.

The API method `registerUsableItem` now return an ID corresponding the the item callback registered for this item.
This ID can then be used later to unregister the specific callback if necessary.

for this, I also added a new API method `unRegisterUsableItem` which take an item name and the callbackId.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

```lua
Citizen.CreateThread(function()
    print("Registering usable item")
    local primaryCbId = exports.vorp_inventory:registerUsableItem("item", function(data)
        print("from callback 1", json.encode(data))
    end)

    local secondaryCbId = exports.vorp_inventory:registerUsableItem("item", function(data)
        print("from callback 2", json.encode(data))
    end)

    -- you can consume the item in game during this time and see both callback being called
    Wait(30000)

    print("Unregistering secondary usable item")
    exports.vorp_inventory:unRegisterUsableItem("item", secondaryCbId)

    -- you can try to consume the item in game, you will see only the first callback being called
    Wait(30000)

    print("Unregistering primary usable item")
    exports.vorp_inventory:unRegisterUsableItem("item", primaryCbId)

    -- you can try to consume the item in game, you will see no callback being called
end)
````

- [X] Tested with latest vorp scripts
- [ ] Tested with latest artifacts

## Notes if any

This update does not break anything. Actually, 100% of the scripts registering usable items are not using the return value because there was none.
