### PR TITLE
Fixed an exploit that allowed people to spawn items

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -1435,6 +1435,15 @@ function InventoryService.MoveToCustom(obj)
 			return print("Error: Amount is greater than item count")
 		end
 
+		--check if the user really has the amount
+		local inventory = UsersInventories.default[sourceIdentifier]
+		if ((not inventory) or (not inventory[item.id]) or inventory[item.id]:getCount() < amount) then
+			local sourceName = sourceCharacter.firstname .. ' ' .. sourceCharacter.lastname
+
+			print("User is probably trying to cheat via NUI, user: " .. sourceName)
+			return
+		end
+
 		if not InventoryService.canStoreItem(sourceIdentifier, sourceCharIdentifier, invId, item.name, amount) then
 			return Core.NotifyRightTip(_source, T.fullInventory, 2000)
 		end


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request

There's an exploit in vorp inventory that allow users to spawn item in custom inventories.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
Those changes should fix the exploit.

### Explain the necessity of these changes and how they will impact the framework or its users.

By using the NUI devtools users can do calls to the NUI registered callbacks manually, the call MoveToCustom is usually called by the UI after the prompt that ask for the quantity of the item to move, and the prompt usually check if you really have that quantity of item.

If you manually call MoveToCustom via a fetch request from the NUI Devtools Vorp inventory doesn't check if you really have the item, it just does subItem to you and addItem to the custom inventory, so by calling the MoveToCustom NUI callback manually without having the right items you are in fact spawning new items without any limit.

Doing a fetch call is also very easy and this exploit could be abused a lot.

Those changes should put an extra check in the MoveToCustom function to check that the user really has the items that it's trying to move.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

The exploit can be tested by moving an item to a custom inventory with the NUI Devtools open and then copying the call as a fetch and running it again inside the vorp inventory iframe.

Without the fix the custom inventory will be filled with a lot of stuff that the user don't have, with the fix it won't allow to move items that you don't have.

I've tested this on vorp_inventory 3.4.

## Notes if any
If there's any need to talk about the exploit and have a demonstration i can show it on discord `celedev97`, i won't be posting here an example of the fetch request to do to dupe item because otherwise people will start doing it.
