### PR TITLE
fix: useing wrong desc  needed to be useing `getCustomDesc`

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -804,7 +804,9 @@ function InventoryService.giveWeapon2(player, weaponId, target)
 	local charname, scourceidentifier, steamname = getSourceInfo(_source)
 	local charname2, scourceidentifier2, steamname2 = getSourceInfo(target)
 	local notListed = false
-
+	if not desc then  
+		desc = userWeapons[weaponId]:getDesc()
+	end
 	if Config.JobsAllowed[job] then
 		DefaultAmount = Config.JobsAllowed[job]
 	end
@@ -848,9 +850,7 @@ function InventoryService.giveWeapon2(player, weaponId, target)
 	TriggerClientEvent("vorpinventory:updateinventorystuff", _source)
 	TriggerClientEvent("vorpCoreClient:subWeapon", _target, weaponId)
 
-	if not desc or desc == "" then
-		desc = "Custom Description not set"
-	end
+	
 	if not serialNumber or serialNumber == "" then
 		serialNumber = "Serial Number not set"
 	end

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -800,7 +800,7 @@ function InventoryService.giveWeapon2(player, weaponId, target)
 	local DefaultAmount = Config.MaxItemsInInventory.Weapons
 	local weaponName = userWeapons[weaponId]:getName()
 	local serialNumber = userWeapons[weaponId]:getSerialNumber()
-	local desc = userWeapons[weaponId]:getDesc()
+	local desc = userWeapons[weaponId]:getCustomDesc()
 	local charname, scourceidentifier, steamname = getSourceInfo(_source)
 	local charname2, scourceidentifier2, steamname2 = getSourceInfo(target)
 	local notListed = false
@@ -855,7 +855,7 @@ function InventoryService.giveWeapon2(player, weaponId, target)
 		serialNumber = "Serial Number not set"
 	end
 	local title = T.WebHookLang.gavewep
-	local description = "**" .. T.WebHookLang.charname .. ":** `" .. charname .. "`\n**" .. T.WebHookLang.Steamname .. "** `" .. steamname .. "` \n**" .. T.WebHookLang.give .. "**  **" .. 1 .. "** \n**" .. T.WebHookLang.Weapontype .. ":** `" .. weaponName .. "` \n**" .. T.WebHookLang.Desc .. "** `" .. desc .. "`   **" .. T.to .. "**   \n` " .. charname2 .. "` \n**" .. T.WebHookLang.Steamname .. "** ` " .. steamname2 .. "`\n **" .. T.WebHookLang.serialnumber .. "** `" .. serialNumber .. "`"
+	local description = "**" .. T.WebHookLang.charname .. ":** `" .. charname2 .. "`\n**" .. T.WebHookLang.Steamname .. "** `" .. steamname2 .. "` \n**" .. T.WebHookLang.give .. "**  **" .. 1 .. "** \n**" .. T.WebHookLang.Weapontype .. ":** `" .. weaponName .. "` \n**" .. T.WebHookLang.Desc .. "** `" .. desc .. "`\n **" .. T.WebHookLang.serialnumber .. "** `" .. serialNumber .. "`\n **" .. T.to .. ":** ` " .. charname .. "` \n**" .. T.WebHookLang.Steamname .. "** ` " .. steamname .. "` "
 	local info = { source = _source, name = Logs.WebHook.webhookname, title = title, description = description, webhook = Logs.WebHook.webhook, color = Logs.WebHook.colorgiveWep }
 	SvUtils.SendDiscordWebhook(info)
 	-- notify


### PR DESCRIPTION
this will fix the using wrong  and it will also fix the wrong player it was backwards  player giving was the player receiving the weapon

# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request

- when giving weapons with CustomDesc would always show the default it was trying to get `getDesc()` not `getCustomDesc()`

- also the info shown in the long was reversed the player getting the weapon was shown as giving it  

![image](https://github.com/VORPCORE/vorp_inventory-lua/assets/26008458/09ec982e-59aa-45fd-ab04-11f783b31ed6)
ignore the CustomDesc lol i told him to type anything... 

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.

to show the right info in the logs 

### Explain the necessity of these changes and how they will impact the framework or its users.

no impact 

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
explanation field
