### PR TITLE
Update inventoryApiService.lua

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -1570,6 +1570,7 @@ function InventoryAPI.openInventory(player, id)
 
 	local function triggerAndReloadInventory()
 		TriggerClientEvent("vorp_inventory:OpenCustomInv", _source, CustomInventoryInfos[id]:getName(), id, capacity, weight)
+		TriggerEvent("vorp_inventory:OpenCustomInv", _source, CustomInventoryInfos[id]:getName(), id, capacity, weight)
 		InventoryService.reloadInventory(_source, id)
 	end
 


### PR DESCRIPTION
Fire the event server internally, too.

# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
To trigger the event within the server it is possible to use the event by other scripts directly within the server instead of listening the event by the clients and re-fire the result to the server (which causes traffic).

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
I want a solution to listen to "custom inventory open" on server side directly.

### Explain the necessity of these changes and how they will impact the framework or its users.
As developer which uses the framework it will help to build a performant solution to keep track of opened custom inventories. Currently I only can listen via clients for that event and trigger a server event to inform the server in my scripts. This is an unnecessary detour that would only cause additional traffic.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. I have tested it locally to ensure the event was thrown server internally whithout errors.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
The background is as follows: We have a quest script. In the script, an item is placed in the inventory with which you can open the quest log. We want to prevent this item from being moved from the player's inventory to any other inventory. There is the command "blackListCustomAny", but you have to know the custom inventories already, because you have to execute this command for every custom inventory that exists (if you know it). If we are informed via an event when any custom inventory is opened, we can execute the command on demand for the respective custom inventory. This means that we do not need to know every custom inventory in advance, but we can blacklist the item in every custom inventory. It is a pity that there is no function that restricts an item to the player inventory in general, this would be the better way, I am aware of that. If there is a better solution I would be thankfull.