### PR TITLE
Add: blacklist check for syn script inventory

### DIFF
--- a/client/services/synFunctions.lua
+++ b/client/services/synFunctions.lua
@@ -1,3 +1,17 @@
+local Core       = exports.vorp_core:GetCore()
+local itemBlacklist = nil
+
+RegisterNetEvent('syn:SendBlacklist', function(blacklist)
+    itemBlacklist = blacklist
+end)
+local function isBlacklisted(itemBlacklist,itemName)
+    for _, blacklistedItem in ipairs(itemBlacklist) do
+        if blacklistedItem == itemName then
+            return true
+        end
+    end
+    return false
+end
 function NUIService.OpenClanInventory(clanName, clanId, capacity)
     ApplyPosfx()
     SetNuiFocus(true, true)
@@ -13,6 +27,10 @@ function NUIService.OpenClanInventory(clanName, clanId, capacity)
 end
 
 function NUIService.NUIMoveToClan(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("syn_clan:MoveToClan", json.encode(obj))
 end
 
@@ -38,6 +56,10 @@ function NUIService.OpenContainerInventory(ContainerName, Containerid, capacity)
 end
 
 function NUIService.NUIMoveToContainer(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("syn_Container:MoveToContainer", json.encode(obj))
 end
 
@@ -65,6 +87,10 @@ function NUIService.OpenHorseInventory(horseTitle, horseId, capacity)
 end
 
 function NUIService.NUIMoveToHorse(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("vorp_stables:MoveToHorse", json.encode(obj))
 end
 
@@ -77,6 +103,10 @@ function NUIService.NUITakeFromHorse(obj)
 end
 
 function NUIService.NUIMoveToStore(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("syn_store:MoveToStore", json.encode(obj))
 end
 
@@ -150,6 +180,10 @@ function NUIService.OpenCartInventory(cartName, wagonId, capacity)
 end
 
 function NUIService.NUIMoveToCart(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("vorp_stables:MoveToCart", json.encode(obj))
 end
 
@@ -176,6 +210,10 @@ function NUIService.OpenHouseInventory(houseName, houseId, capacity)
 end
 
 function NUIService.NUIMoveToHouse(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("vorp_housing:MoveToHouse", json.encode(obj))
 end
 
@@ -202,6 +240,10 @@ function NUIService.OpenHideoutInventory(hideoutName, hideoutId, capacity)
 end
 
 function NUIService.NUIMoveToHideout(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("syn_underground:MoveToHideout", json.encode(obj))
 end
 
@@ -228,6 +270,10 @@ function NUIService.OpenBankInventory(bankName, bankId, capacity)
 end
 
 function NUIService.NUIMoveToBank(obj)
+    if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
+        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        return 
+    end
     TriggerServerEvent("vorp_bank:MoveToBank", json.encode(obj))
 end
 

--- a/client/services/synFunctions.lua
+++ b/client/services/synFunctions.lua
@@ -1,6 +1,6 @@
 local Core       = exports.vorp_core:GetCore()
 local itemBlacklist = nil
-
+local T          = TranslationInv.Langs[Lang]
 RegisterNetEvent('syn:SendBlacklist', function(blacklist)
     itemBlacklist = blacklist
 end)
@@ -28,7 +28,7 @@ end
 
 function NUIService.NUIMoveToClan(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip( T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("syn_clan:MoveToClan", json.encode(obj))
@@ -57,7 +57,7 @@ end
 
 function NUIService.NUIMoveToContainer(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("syn_Container:MoveToContainer", json.encode(obj))
@@ -88,7 +88,7 @@ end
 
 function NUIService.NUIMoveToHorse(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("vorp_stables:MoveToHorse", json.encode(obj))
@@ -104,7 +104,7 @@ end
 
 function NUIService.NUIMoveToStore(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("syn_store:MoveToStore", json.encode(obj))
@@ -181,7 +181,7 @@ end
 
 function NUIService.NUIMoveToCart(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("vorp_stables:MoveToCart", json.encode(obj))
@@ -211,7 +211,7 @@ end
 
 function NUIService.NUIMoveToHouse(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("vorp_housing:MoveToHouse", json.encode(obj))
@@ -241,7 +241,7 @@ end
 
 function NUIService.NUIMoveToHideout(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("syn_underground:MoveToHideout", json.encode(obj))
@@ -271,7 +271,7 @@ end
 
 function NUIService.NUIMoveToBank(obj)
     if itemBlacklist and isBlacklisted(itemBlacklist, obj.item.name) then
-        Core.NotifyRightTip("You can't move this item to the house.", 4000)
+        Core.NotifyRightTip(T.Blacklisteditem, 4000)
         return 
     end
     TriggerServerEvent("vorp_bank:MoveToBank", json.encode(obj))

--- a/languages/language.lua
+++ b/languages/language.lua
@@ -67,6 +67,7 @@ TranslationInv.Langs = {
         gaveMoney                 = "Gave money",
         withid                    = " with the weapon ID: ",
         serialnumber              = "Serial Number: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
         labels                    = {
             weight = "Weight ",
             serial = "Serial no ",
@@ -164,6 +165,8 @@ TranslationInv.Langs = {
         gave                      = "Deu Dinheiro",
         withid                    = " com o ID da arma: ",
         serialnumber              = "Número de série: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Peso ",
             serial = "Número de Série ",
@@ -267,6 +270,8 @@ TranslationInv.Langs = {
         gaveMoney                 = "Deu dinheiro",
         withid                    = " com o ID da arma: ",
         serialnumber              = "Número de série: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Peso ",
             serial = "Número de Série ",
@@ -365,6 +370,8 @@ TranslationInv.Langs = {
         gave                      = "Gave money",
         withid                    = " avec l'ID de l'arme: ",
         serialnumber              = "Numéro de série: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Poids ",
             serial = "Numéro de série ",
@@ -461,6 +468,8 @@ TranslationInv.Langs = {
         gave                      = "Gave money",
         withid                    = " mit der Waffen ID: ",
         serialnumber              = "Seriennummer: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Gewicht ",
             serial = "Seriennummer ",
@@ -560,6 +569,8 @@ TranslationInv.Langs = {
         gave                      = "Gave money",
         withid                    = " con el ID de arma: ",
         serialnumber              = "Número de serie: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Peso ",
             serial = "Número de serie ",
@@ -657,6 +668,8 @@ TranslationInv.Langs = {
         transfered                = " ha trasferito ",
         withid                    = " con ID arma: ",
         serialnumber              = "Numero di serie: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Peso ",
             serial = "Numero seriale ",
@@ -758,6 +771,8 @@ TranslationInv.Langs = {
         gave                      = "Gave money",
         withid                    = " met wapen ID: ",
         serialnumber              = "Serienummer: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Gewicht ",
             serial = "Serienummer ",
@@ -855,6 +870,8 @@ TranslationInv.Langs = {
         gave                      = "Gave money",
         withid                    = " med våpen ID: ",
         serialnumber              = "Serienummer: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Vekt ",
             serial = "Serienummer ",
@@ -950,6 +967,8 @@ TranslationInv.Langs = {
         gave                      = "Gave money",
         withid                    = " with weapon ID: ",
         serialnumber              = "Seri numarası: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Ağırlık ",
             serial = "Seri numarası ",
@@ -1048,6 +1067,8 @@ TranslationInv.Langs = {
         gaveMoney                 = "Ai dat bani",
         withid                    = " cu ID-ul armei: ",
         serialnumber              = "Numar de serie: ",
+        Blacklisteditem        = "you can't place this item in this Inventory ",
+
         labels                    = {
             weight = "Greutate ",
             serial = "Numar de serie ",


### PR DESCRIPTION
adding  blacklist check for  items from being put in a inv  from syn scripts

# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
i was looking to add black list to prevent the syn scripts inv from allowing some items to be placed set in the config of the script 

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.

talking with blue about adding blacklists to the invs for the script and this was what i had done and tested 
to adds item blacklist to the syn scripts it all works and if added will have the syn script all updated to use as well 

### Explain the necessity of these changes and how they will impact the framework or its users.

should not impact the framework or its users
### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

i have tested with all syn scripts that use the synfunctions.lua  already and done all changes on the client to send the black list when the player opens the inv then it will check the item with the black list  if in the list it i will let you know you cant place in this inv if there is no blacklist set it allows all just like before 



- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any

if you don't use syn scripts this will not effect anyone in anyway

```lua
RegisterNetEvent('syn:SendBlacklist', function(blacklist)
    itemBlacklist = blacklist
end)
```
syn:SendBlacklist is added to be triggered by the syn scripts to get the blacklist info will only be triggered when opening the inv to update the blacklist for that script inv 
triggered in the syn scripts  clients with 


```lua
TriggerEvent('syn:SendBlacklist', Config.synBlacklist)
```
isBlacklisted is  going to be used when the player move the item and checks it 

```lua
local function isBlacklisted(itemBlacklist,itemName)
    for _, blacklistedItem in ipairs(itemBlacklist) do
        if blacklistedItem == itemName then
            return true
        end
    end
    return false
end
```
