### PR TITLE
Fix getPercentage()

### DIFF
--- a/shared/models/ItemClass.lua
+++ b/shared/models/ItemClass.lua
@@ -92,7 +92,7 @@ function Item:getPercentage(maxDegradation, degradation)
 		return self.percentage
 	end
 
-	return 0
+	return 100
 end
 
 function Item:getMaxDegradation()


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Currently the getItemCount doesnt count non degrable items as present when you filter for at least 1%

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
That in a for loop that checks mutliple items that may have degration or not get counted correctly

### Explain the necessity of these changes and how they will impact the framework or its users.
Currently non degrable items getting filtered out because the return is 0 and so on smaller then 1 but the return only happens if an item is not degrable at all

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. 

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
