### PR TITLE
Added items crafted id in "getAllItemsFromCustomInventory" function

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -2000,6 +2000,7 @@ function InventoryService.getAllItemsFromCustomInventory(invId)
 
 			if next(itemMetadata) then
 				items[#items + 1] = {
+					crafted_id = value.item_crafted_id,
 					name = value.item_name,
 					amount = value.amount,
 					metadata = itemMetadata,
@@ -2010,6 +2011,7 @@ function InventoryService.getAllItemsFromCustomInventory(invId)
 					itemsMap[value.item_name].amount = itemsMap[value.item_name].amount + value.amount
 				else
 					itemsMap[value.item_name] = {
+						crafted_id = value.item_crafted_id,
 						name = value.item_name,
 						amount = value.amount,
 						metadata = itemMetadata,


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Added "crafted_id" of items returned by the "getAllItemsFromCustomInventory" function.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
The crafted id is an essential identifier if for example we need to update an item from a custom inventory.

### Explain the necessity of these changes and how they will impact the framework or its users.
It won't change anything in the user experience, it's just additional data in a function.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.
Code example:
```lua

local items = exports.vorp_inventory:getCustomInventoryItems("my_awesome_inventory")
for _, i in ipairs(items) do
    print(i.crafted_id)
end

local isItemUpdated = exports.vorp_inventory:updateCustomInventoryItem("my_awesome_inventory", items[1].crafted_id, {}, 5)
if (isItemUpdated) then
    print("GG for this update!")
end
```

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts