### PR TITLE
Chore: add notify when you try to exceed the max item transfer limit 

### DIFF
--- a/client/controllers/NUIController.lua
+++ b/client/controllers/NUIController.lua
@@ -13,6 +13,8 @@ RegisterNUICallback("TakeFromPlayer", NUIService.NUITakeFromPlayer)
 RegisterNUICallback("MoveToPlayer", NUIService.NUIMoveToPlayer)
 RegisterNUICallback('getActionsConfig', NUIService.getActionsConfig)
 RegisterNUICallback('ContextMenu', NUIService.ContextMenu)
+RegisterNUICallback('TransferLimitExceeded', NUIService.TransferLimitExceeded)
+
 --========================================================================--
 -- shared
 RegisterNetEvent("vorp_inventory:CloseInv")

--- a/client/services/NUIService.lua
+++ b/client/services/NUIService.lua
@@ -121,6 +121,12 @@ function NUIService.NUITakeFromPlayer(obj)
 	TriggerServerEvent("vorp_inventory:TakeFromPlayer", json.encode(obj))
 end
 
+function NUIService.TransferLimitExceeded(maxValue)
+    local message = string.format(T.MaxItemtrasfer, maxValue.max)
+    Core.NotifyRightTip(message, 4000)
+end
+
+
 function NUIService.CloseInv()
 	if Config.UseFilter then
 		AnimpostfxStop(Config.Filter)

--- a/html/js/config.js
+++ b/html/js/config.js
@@ -6,3 +6,4 @@ Config.AddDollarItem = false;
 Config.AddAmmoItem = false;
 Config.DoubleClickToUse = true;
 Config.WeightMeasure = "kg";
+Config.MaxItemTransferAmount = 200;

--- a/html/js/secondaryInvScript.js
+++ b/html/js/secondaryInvScript.js
@@ -47,7 +47,11 @@ function PostAction(eventName, itemData, id, propertyName, info) {
             },
 
             validate: function (value, item, type) {
-                if (!value || value <= 0 || value > 200 || !isInt(value)) {
+                if (!value || value <= 0 || value > Config.MaxItemTransferAmount || !isInt(value)) {
+                    $.post(`https://${GetParentResourceName()}/TransferLimitExceeded`, JSON.stringify({
+                        max: Config.MaxItemTransferAmount
+                    }));
+                                    
                     dialog.close();
                 } else {
                     PostActionPostQty(eventName, itemData, id, propertyName, value, info);


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request

this the moment there is no way to know there is limit in game other then it just doing nothing at all 
adding this will let the player know there is a limit and you cant go above it 

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.

I spent almost a hour trying to figure why i cant go above 200 and it hard coded to the JS  after speaking with outsider i found this out and just wanted to add a notify message to let players know  

I understand there is a limit for a reason and this dose not remove it but allow to set and use that to check and send notify to player that there is one and its not broken 

### Explain the necessity of these changes and how they will impact the framework or its users.
explanation field

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts

## Notes if any
explanation field
