### PR TITLE
allow setting negative numbers to ignore stack limit

### DIFF
--- a/shared/models/ItemClass.lua
+++ b/shared/models/ItemClass.lua
@@ -213,7 +213,7 @@ function Item:getCount()
 end
 
 function Item:addCount(amount, ignoreStackLimit)
-	if (self.count + amount <= self.limit) or ignoreStackLimit or self.limit == -1 then
+	if self.limit == -1 or (self.count + amount <= self.limit) or ignoreStackLimit then
 		self.count = self.count + amount
 		return true
 	end

--- a/shared/models/ItemClass.lua
+++ b/shared/models/ItemClass.lua
@@ -122,7 +122,9 @@ function Item:isItemExpired(degradation, maxDegradation)
 		end
 
 		local percentage = self:getPercentage(maxDegradation, degradation)
-		if percentage == 0 then return true end
+		if percentage == 0 then
+			return true
+		end
 
 		return false
 	end
@@ -133,7 +135,9 @@ function Item:isItemExpired(degradation, maxDegradation)
 		end
 
 		local percentage = self:getPercentage()
-		if percentage == 0 then return true end
+		if percentage == 0 then
+			return true
+		end
 	end
 
 	return false
@@ -209,7 +213,7 @@ function Item:getCount()
 end
 
 function Item:addCount(amount, ignoreStackLimit)
-	if (self.count + amount <= self.limit) or ignoreStackLimit then
+	if (self.count + amount <= self.limit) or ignoreStackLimit or self.limit == -1 then
 		self.count = self.count + amount
 		return true
 	end


### PR DESCRIPTION
## Type of change

- [X ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Had an issue where items were not added because limit was set to -1 (we want weight limit to determine how much you can carry for most items)

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
Allow limit to be set to -1 and allow to ignore stack limit when adding item.


### Explain the necessity of these changes and how they will impact the framework or its users.
No real impact except more customization

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. 
Set item limit to -1 in DB for item 
Try to add -1 item 
All is triggered but item count does not update

After
Repeat but the item count will go up

- [X ] Tested with latest vorp scripts
- [ ] Tested with latest artifacts



