### PR TITLE
fix(server): charid permissions

### DIFF
--- a/server/services/inventoryApiService.lua
+++ b/server/services/inventoryApiService.lua
@@ -1678,12 +1678,11 @@ exports("AddPermissionTakeFromCustom", InventoryAPI.AddPermissionTakeFromCustom)
 ---@param charid string charid
 ---@param state boolean | nil
 function InventoryAPI.AddCharIdPermissionMoveToCustom(id, charid, state)
-	if canContinue(id, false, false, charid) then
+	if not canContinue(id, false, false, charid) then
 		return
 	end
 
-	local data = { name = charid, state = state }
-	CustomInventoryInfos[id]:AddCharIdPermissionMoveTo(data)
+	CustomInventoryInfos[id]:AddCharIdPermissionMoveTo(charid, state)
 end
 
 exports("AddCharIdPermissionMoveToCustom", InventoryAPI.AddCharIdPermissionMoveToCustom)
@@ -1693,12 +1692,11 @@ exports("AddCharIdPermissionMoveToCustom", InventoryAPI.AddCharIdPermissionMoveT
 ---@param charid string charid
 ---@param state boolean | nil
 function InventoryAPI.AddCharIdPermissionTakeFromCustom(id, charid, state)
-	if canContinue(id, false, false, charid) then
+	if not canContinue(id, false, false, charid) then
 		return
 	end
 
-	local data = { charid = charid, state = state }
-	CustomInventoryInfos[id]:AddCharIdPermissionTakeFrom(data)
+	CustomInventoryInfos[id]:AddCharIdPermissionTakeFrom(charid, state)
 end
 
 exports("AddCharIdPermissionTakeFromCustom", InventoryAPI.AddCharIdPermissionTakeFromCustom)


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
Had an issue with charid permissions when i used the AddCharIdPermissionTakeFromCustom and AddCharIdPermissionMoveToCustom exports the character was not whitelist to take from custom or move to custom since the script send a data and not the charid and state

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
With this changes the permissions for charid to take from or move to works perfectly so peoples can use it in custom inventories

### Explain the necessity of these changes and how they will impact the framework or its users.
No real impact and peoples can use custom inventory permissions

### Please describe the tests you have conducted to verify your changes. Provide instructions so we i register an custom inventory and i add my charid permissions to takefrom and moveto with the exporters, also i test alone the takefrom permission enable and the moveto also. All my test works perfectly.

- [X] Tested with latest vorp scripts
- [X] Tested with latest artifacts