### PR TITLE
Add a config option to disable duel wielding. (Enabled by default)

### DIFF
--- a/client/services/NUIService.lua
+++ b/client/services/NUIService.lua
@@ -374,8 +374,10 @@ local function useWeapon(data)
 	local isWeaponOneHanded = Citizen.InvokeNative(0xD955FEE4B87AFA07, weapName)
 	local isArmed = Citizen.InvokeNative(0xCB690F680A3EA971, ped, 4)
 	local notdual = false
-
-	if (isWeaponAGun and isWeaponOneHanded) and isArmed then
+	if (isWeaponAGun and isWeaponOneHanded) and isArmed and not Config.DuelWield then
+		Core.NotifyRightTip("You cannot duel wield pistols!")
+		return
+	elseif (isWeaponAGun and isWeaponOneHanded) and isArmed and Config.DuelWield then
 		addWardrobeInventoryItem("CLOTHING_ITEM_M_OFFHAND_000_TINT_004", 0xF20B6B4A)
 		addWardrobeInventoryItem("UPGRADE_OFFHAND_HOLSTER", 0x39E57B01)
 		UserWeapons[weaponId]:setUsed2(true)

--- a/client/services/NUIService.lua
+++ b/client/services/NUIService.lua
@@ -375,7 +375,6 @@ local function useWeapon(data)
 	local isArmed = Citizen.InvokeNative(0xCB690F680A3EA971, ped, 4)
 	local notdual = false
 	if (isWeaponAGun and isWeaponOneHanded) and isArmed and not Config.DuelWield then
-		Core.NotifyRightTip("You cannot duel wield pistols!")
 		return
 	elseif (isWeaponAGun and isWeaponOneHanded) and isArmed and Config.DuelWield then
 		addWardrobeInventoryItem("CLOTHING_ITEM_M_OFFHAND_000_TINT_004", 0xF20B6B4A)

--- a/config/config.lua
+++ b/config/config.lua
@@ -58,6 +58,8 @@ Config = {
 		Time = 10, -- after this time pick up wll be deleted, IN MINUTES
 	},
 
+	DuelWield				   = false,   -- If true duel wielding will be allowed.
+
 	-- =================== CLEAR ITEMS WEAPONS MONEY GOLD ===================== --
 
 	UseClearAll                = false, -- If you want to use the clear item function

--- a/config/config.lua
+++ b/config/config.lua
@@ -58,7 +58,7 @@ Config = {
 		Time = 10, -- after this time pick up wll be deleted, IN MINUTES
 	},
 
-	DuelWield				   = false,   -- If true duel wielding will be allowed.
+	DuelWield				   = true,   -- If true duel wielding will be allowed.
 
 	-- =================== CLEAR ITEMS WEAPONS MONEY GOLD ===================== --
 


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Motive for This Pull Request
Some servers may not want duel wielding enabled and it was not a config option.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
This disables duel wielding and displays an error message if you attempt to equip another pistol.

### Explain the necessity of these changes and how they will impact the framework or its users.
This will allow people to disable duel wielding, it is enabled by default.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts

## Notes if any
I have left duel wielding as enabled by default so it doesn't make any changes by default.
