### PR TITLE
Fix: NUIService StoreSynMenu extra metadata being added to item

### DIFF
--- a/client/services/NUIService.lua
+++ b/client/services/NUIService.lua
@@ -463,10 +463,10 @@ local function loadItems()
 					if item.name == v.name then
 						if item.metadata.description ~= nil then
 							item.metadata.orgdescription = item.metadata.description
-							item.metadata.description = item.metadata.description .. "<br><span style=color:Green;>" .. T.cansell .. v.price .. "</span>"
+							item.metadata.description = T.cansell .."<span style=color:Green;>" .. v.price .. "</span>"
 						else
 							item.metadata.orgdescription = ""
-							item.metadata.description = "<span style=color:Green;>" .. T.cansell .. v.price .. "</span>"
+							item.metadata.description = T.cansell .."<span style=color:Green;>" .. v.price .. "</span>"
 						end
 					end
 				end


### PR DESCRIPTION
# Pull request template
> [!IMPORTANT]
> Please complete all fields. PRs will not be merged if any fields are incomplete. Be respectful, and keep in mind that it may take some time for your PR to be reviewed.
>
> Bear in mind refactors are up to the developers and not it's contributors after all we are the ones giving support when needed. if they are big changes I suggest you to release it under your name instead.

## Type of change

- [ X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Motive for This Pull Request
from time to time items would get extra  
```
T.cansell .. v.price .. "</span>
```
added to the metadata for description and would brake items from some scripts this should remove the extra being added 


### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.



### Explain the necessity of these changes and how they will impact the framework or its users.
explanation field

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. Also, list any relevant details for your test configuration.

- [ X ] Tested with latest vorp scripts
- [ X ] Tested with latest artifacts

## Notes if any
explanation field
