### PR TITLE
Update inventoryService.lua

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -1830,6 +1830,7 @@ function InventoryService.MoveToPlayer(obj)
 					if result then
 						InventoryService.reloadInventory(target, "default", "player", _source)
 						InventoryService.DiscordLogs("default", item.name, amount, sourceName, "Move")
+						SvUtils.Trem(_source)
 					end
 				end)
 			else


### PR DESCRIPTION
We have identified the issue related to the InventoryService.MoveToPlayer function which gets stuck in loading player inventory when moving a weapon from the player's inventory to the target's inventory.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [x] Tested with latest vorp scripts 
 
