### PR TITLE
Custom Inventory Server Events

### DIFF
--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -1749,7 +1749,7 @@ function InventoryService.TakeFromCustom(obj)
 				return Core.NotifyObjective(_source, T.cantRemoveItem, 2000)
 			end
 
-			TriggerEvent("vorp_inventory:Server:OnItemTakenFromCustomInventory", {id = item:getId(), name = item.name, amount = amount}, invId, _source)
+			TriggerEvent("vorp_inventory:Server:OnItemTakenFromCustomInventory", {id = itemAdded:getId(), name = item.name, amount = amount}, invId, _source)
 			TriggerClientEvent("vorpInventory:receiveItem", _source, item.name, itemAdded:getId(), amount, itemAdded:getMetadata(), itemAdded:getDegradation(), itemAdded:getPercentage())
 			InventoryService.reloadInventory(_source, invId)
 			InventoryService.DiscordLogs(invId, item.name, amount, sourceName, "Take")

--- a/server/services/inventoryService.lua
+++ b/server/services/inventoryService.lua
@@ -1648,6 +1648,7 @@ function InventoryService.MoveToCustom(obj)
 			end
 
 			InventoryService.subItem(_source, "default", item.id, amount)
+			TriggerEvent("vorp_inventory:Server:OnItemMovedToCustomInventory", {id = item.id, name = item.name, amount = amount}, invId, _source)
 			TriggerClientEvent("vorpInventory:removeItem", _source, item.name, item.id, amount)
 			Core.NotifyRightTip(_source, T.movedToStorage .. " " .. amount .. " " .. item.label, 2000)
 			InventoryService.reloadInventory(_source, invId)
@@ -1748,6 +1749,7 @@ function InventoryService.TakeFromCustom(obj)
 				return Core.NotifyObjective(_source, T.cantRemoveItem, 2000)
 			end
 
+			TriggerEvent("vorp_inventory:Server:OnItemTakenFromCustomInventory", {id = item:getId(), name = item.name, amount = amount}, invId, _source)
 			TriggerClientEvent("vorpInventory:receiveItem", _source, item.name, itemAdded:getId(), amount, itemAdded:getMetadata(), itemAdded:getDegradation(), itemAdded:getPercentage())
 			InventoryService.reloadInventory(_source, invId)
 			InventoryService.DiscordLogs(invId, item.name, amount, sourceName, "Take")


### PR DESCRIPTION
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Motive for This Pull Request
This merge adds 2 server-side events for the TakeFrom and MoveTo custom inventory actions.

### Provide a brief explanation of why these changes are being proposed and what they aim to achieve.
We lack custom inventory control, additional events are always useful to use.

### Explain the necessity of these changes and how they will impact the framework or its users.
This does not require any special changes and will have no impact for users except developers.

### Please describe the tests you have conducted to verify your changes. Provide instructions so we can reproduce these tests. 
Item is a table composed of "id", "name" and "amount".
```lua
AddEventHandler("vorp_inventory:Server:OnItemTakenFromCustomInventory", function(item, invId, source)
    print("OnItemTakenFromCustomInventory", json.encode(item), invId, source)
end)

AddEventHandler("vorp_inventory:Server:OnItemMovedToCustomInventory", function(item, invId, source)
    print("OnItemMovedToCustomInventory", json.encode(item), invId, source)
end)
```

- [x] Tested with latest vorp scripts
- [x] Tested with latest artifacts
